### PR TITLE
Allow empty csv cell strings in generic derivation

### DIFF
--- a/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/MapShapedCsvRowDecoder.scala
+++ b/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/MapShapedCsvRowDecoder.scala
@@ -90,7 +90,7 @@ private[generic] trait LowPriorityMapShapedCsvRowDecoder1 {
                           default: Option[Head] :: DefaultTail,
                           anno: Anno :: AnnoTail): DecoderResult[FieldType[Key, Head] :: Tail] = {
         val head = row(anno.head.fold(witness.value.name)(_.name)) match {
-          case Some(head) if head.nonEmpty =>
+          case Some(head) =>
             Head(head).leftMap(_.withLine(row.line))
           case _ =>
             default.head.liftTo[DecoderResult](

--- a/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/internal/OptCellDecoder.scala
+++ b/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/internal/OptCellDecoder.scala
@@ -9,14 +9,15 @@ sealed trait OptCellDecoder[T] {
 
 object OptCellDecoder extends LowPrioOptCellDecoders {
   given makeNonOpt[A: CellDecoder]: OptCellDecoder[A] = new OptCellDecoder[A] {
-    override def apply(name: String, value: Option[String]): DecoderResult[A] =
-      value.toRight(new DecoderError(s"Missing column $name")).flatMap(CellDecoder[A].apply)
+    override def apply(name: String, value: Option[String]): DecoderResult[A] = {
+      CellDecoder[A].apply(value.orEmpty)
+    }
   }
 }
 
 trait LowPrioOptCellDecoders {
   given makeOpt[A: CellDecoder]: OptCellDecoder[Option[A]] = new OptCellDecoder[Option[A]] {
     override def apply(name: String, value: Option[String]): DecoderResult[Option[A]] =
-      value.traverse(CellDecoder[A].apply(_))
+      value.filter(_.nonEmpty).traverse(CellDecoder[A].apply(_))
   }
 }

--- a/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/semiauto.scala
+++ b/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/semiauto.scala
@@ -37,7 +37,7 @@ object semiauto {
           ic.unfold[(Int, List[String], Option[DecoderError])]((0, row.values.toList, None))(
             [t] =>
               (acc: (Int, List[String], Option[DecoderError]), cd: OptCellDecoder[t]) => {
-                val result = cd(s"at index ${acc._1}", acc._2.headOption.filter(_.nonEmpty))
+                val result = cd(s"at index ${acc._1}", acc._2.headOption)
                 ((acc._1 + 1, acc._2.tail, result.left.toOption), result.toOption)
             }
           )
@@ -67,7 +67,7 @@ object semiauto {
           [t] =>
             (acc: (Int, CsvRow[String], Option[DecoderError]), cd: OptCellDecoder[t]) => {
               val columnName = names(acc._1)
-              val result = cd.apply(columnName, acc._2(columnName).filter(_.nonEmpty))
+              val result = cd.apply(columnName, acc._2(columnName))
               ((acc._1 + 1, row, result.left.toOption), result.toOption)
           }
         )

--- a/csv/generic/shared/src/test/scala/fs2/data/csv/generic/CsvRowDecoderTest.scala
+++ b/csv/generic/shared/src/test/scala/fs2/data/csv/generic/CsvRowDecoderTest.scala
@@ -33,16 +33,19 @@ object CsvRowDecoderTest extends SimpleIOSuite {
     CsvRow.unsafe(NonEmptyList.of("1", "test", ""), NonEmptyList.of("i", "s", "j"))
   val csvRowNoJ =
     CsvRow.unsafe(NonEmptyList.of("1", "test"), NonEmptyList.of("i", "s"))
+  val csvRowEmptyCell = CsvRow.unsafe(NonEmptyList.of("1", "", "42"), NonEmptyList.of("i", "s", "j"))
 
   case class Test(i: Int = 0, s: String, j: Option[Int])
   case class TestOrder(s: String, j: Int, i: Int = 8888888)
   case class TestRename(s: String, @CsvName("j") k: Int, i: Int)
   case class TestOptionRename(s: String, @CsvName("j") k: Option[Int], i: Int)
+  case class TestOptionalString(i: Int, s: Option[String], j: Int)
 
   val testDecoder = deriveCsvRowDecoder[Test]
   val testOrderDecoder = deriveCsvRowDecoder[TestOrder]
   val testRenameDecoder = deriveCsvRowDecoder[TestRename]
   val testOptionRenameDecoder = deriveCsvRowDecoder[TestOptionRename]
+  val testOptionalStringDecoder = deriveCsvRowDecoder[TestOptionalString]
 
   pureTest("case classes should be decoded properly by header name and not position") {
     expect(testDecoder(csvRow) == Right(Test(1, "test", Some(42)))) and
@@ -72,6 +75,11 @@ object CsvRowDecoderTest extends SimpleIOSuite {
   pureTest("case classes should be decoded according to their field renames if value is optional") {
     expect(testOptionRenameDecoder(csvRow) == Right(TestOptionRename("test", Some(42), 1))) and
       expect(testOptionRenameDecoder(csvRowNoJ) == Right(TestOptionRename("test", None, 1)))
+  }
+
+  pureTest("allow empty strings as string cell values") {
+    expect(testDecoder(csvRowEmptyCell) == Right(Test(1, "", Some(42)))) and
+      expect(testOptionalStringDecoder(csvRowEmptyCell) == Right(TestOptionalString(1, None, 42)))
   }
 
 }

--- a/csv/generic/shared/src/test/scala/fs2/data/csv/generic/RowDecoderTest.scala
+++ b/csv/generic/shared/src/test/scala/fs2/data/csv/generic/RowDecoderTest.scala
@@ -29,6 +29,7 @@ object RowDecoderTest extends SimpleIOSuite {
   val csvRow = Row(NonEmptyList.of("1", "test", "42"))
   val csvRowEmptyI = Row(NonEmptyList.of("", "test", "42"))
   val csvRowEmptyJ = Row(NonEmptyList.of("1", "test", ""))
+  val csvRowEmptyS = Row(NonEmptyList.of("1", "", "42"))
 
   case class Test(i: Int, s: String, j: Int)
   case class TestOrder(s: String, i: Int, j: Int)
@@ -50,6 +51,10 @@ object RowDecoderTest extends SimpleIOSuite {
       expect(testOptIDecoder(csvRowEmptyI) == Right(TestOptI(None, "test", 42))) and
       expect(testOptJDecoder(csvRow) == Right(TestOptJ(1, "test", Some(42)))) and
       expect(testOptJDecoder(csvRowEmptyJ) == Right(TestOptJ(1, "test", None)))
+  }
+
+  pureTest("allow empty strings as string cell values") {
+    expect(testDecoder(csvRowEmptyS) == Right(Test(1, "", 42)))
   }
 
 }


### PR DESCRIPTION
Was probably meant as an optimization, but there empty strings can be legitimate. Users can still require non-emptiness using a cell decoder or by parsing into Option.