### PR TITLE
CSV decoder Instances for DecoderResult

### DIFF
--- a/csv/shared/src/main/scala/fs2/data/csv/RowDecoderF.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/RowDecoderF.scala
@@ -18,7 +18,7 @@ package fs2.data.csv
 
 import cats._
 import cats.data.{NonEmptyList, NonEmptyMap}
-import cats.implicits._
+import cats.syntax.all._
 
 import scala.annotation.tailrec
 
@@ -136,6 +136,14 @@ object RowDecoderF extends ExportedRowDecoderFs {
 
   implicit val toNelRowDecoder: RowDecoder[NonEmptyList[String]] =
     RowDecoder.instance(_.values.asRight)
+
+  // the following two can't be unified va RowDecoderF because type inference fails us
+  implicit def decodeResultCsvRowDecoder[Header, T](implicit
+      dec: CsvRowDecoder[T, Header]): CsvRowDecoder[DecoderResult[T], Header] =
+    r => Right(dec(r))
+
+  implicit def decodeResultRowDecoder[T](implicit dec: RowDecoder[T]): RowDecoder[DecoderResult[T]] =
+    r => Right(dec(r))
 }
 
 trait ExportedRowDecoderFs {

--- a/csv/shared/src/test/scala/fs2/data/csv/RowDecoderFTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/RowDecoderFTest.scala
@@ -1,0 +1,57 @@
+package fs2
+package data
+package csv
+
+import cats.effect.IO
+import weaver._
+
+object RowDecoderFTest extends SimpleIOSuite {
+
+  case class TwoNumbers(a: Int, b: Int)
+
+  implicit val rowDecoder: RowDecoder[TwoNumbers] = RowDecoder.instance { row =>
+    for {
+      a <- row.asAt[Int](0)
+      b <- row.asAt[Int](1)
+    } yield TwoNumbers(a, b)
+  }
+
+  implicit val csvRowDecoder: CsvRowDecoder[TwoNumbers, String] = CsvRowDecoder.instance { row =>
+    for {
+      a <- row.as[Int]("a")
+      b <- row.as[Int]("b")
+    } yield TwoNumbers(a, b)
+  }
+
+  test("can parse CSV with rows that do not convert by an attempting RowDecoder") {
+    val rows = List(
+      "4,5\n",
+      "6,seven"
+    )
+    Stream
+      .emits[IO, String](rows)
+      .through(decodeWithoutHeaders[DecoderResult[TwoNumbers]]())
+      .compile
+      .toList
+      .map { result =>
+        expect(result.head.isRight) and expect(result.tail.head.isLeft)
+      }
+  }
+
+  test("can parse CSV with rows that do not convert by an attempting CsvRowDecoder") {
+    val rows = List(
+      "a,b\n",
+      "4,5\n",
+      "6,seven"
+    )
+    Stream
+      .emits[IO, String](rows)
+      .through(decodeUsingHeaders[DecoderResult[TwoNumbers]]())
+      .compile
+      .toList
+      .map { result =>
+        expect(result.head.isRight) and expect(result.tail.head.isLeft)
+      }
+  }
+
+}


### PR DESCRIPTION
Allow to work more easily with CSVs that contain bad rows as you can lift the errors to value level more easily and handle them there afterwards.