### PR TITLE
Add asNonEmpty and asNonEmptyAt

### DIFF
--- a/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
@@ -54,6 +54,17 @@ case class RowF[H[+a] <: Option[a], Header](values: NonEmptyList[String],
       case None    => Left(new DecoderError(s"unknown index $idx"))
     }
 
+  /** Returns the decoded content of the cell at `idx` wrapped in Some if the cell is non-empty, None otherwise.
+    * Fails if the index doesn't exist or cannot be decoded
+    * to the expected type.
+    */
+  def asNonEmptyAt[T](idx: Int)(implicit decoder: CellDecoder[T]): DecoderResult[Option[T]] =
+    values.get(idx) match {
+      case Some(v) if v.isEmpty => Right(None)
+      case Some(v)              => decoder(v).map(Some(_))
+      case None                 => Left(new DecoderError(s"unknown index $idx"))
+    }
+
   /** Modifies the cell content at the given `idx` using the function `f`.
     */
   def modifyAt(idx: Int)(f: String => String): RowF[H, Header] =
@@ -139,6 +150,18 @@ case class RowF[H[+a] <: Option[a], Header](values: NonEmptyList[String],
     (byHeader: @nowarn("msg=HasHeaders")).get(header) match {
       case Some(v) => decoder(v)
       case None    => Left(new DecoderError(s"unknown field $header"))
+    }
+
+  /** Returns the decoded content of the cell at `header` wrapped in Some if the cell is non-empty, None otherwise.
+    * Fails if the field doesn't exist or cannot be decoded
+    * to the expected type.
+    */
+  def asNonEmpty[T](
+      header: Header)(implicit hasHeaders: HasHeaders[H, Header], decoder: CellDecoder[T]): DecoderResult[Option[T]] =
+    (byHeader: @nowarn("msg=HasHeaders")).get(header) match {
+      case Some(v) if v.isEmpty => Right(None)
+      case Some(v)              => decoder(v).map(Some(_))
+      case None                 => Left(new DecoderError(s"unknown field $header"))
     }
 
   /** Returns a representation of this row as Map from headers to corresponding cell values.

--- a/csv/shared/src/test/scala/fs2/data/csv/RowFTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/RowFTest.scala
@@ -33,4 +33,23 @@ object RowFTest extends SimpleIOSuite {
       expect.eql(NonEmptyList.of("a", "b", "c", "d"), extended.headers.get)
   }
 
+  pureTest("CsvRow.asNonEmpty should return None for empty cells") {
+    val row = CsvRow.unsafe(NonEmptyList.of("", "2", "3"), NonEmptyList.of("a", "b", "c"))
+    expect(row.asNonEmpty[Int]("a").contains(None))
+  }
+
+  pureTest("CsvRow.asNonEmpty should return decoded value for non-empty cells") {
+    val row = CsvRow.unsafe(NonEmptyList.of("", "2", "3"), NonEmptyList.of("a", "b", "c"))
+    expect(row.asNonEmpty[Int]("b").contains(Some(2)))
+  }
+
+  pureTest("Row.asNonEmptyAt should return None for empty cells") {
+    val row = Row(NonEmptyList.of("", "2", "3"))
+    expect(row.asNonEmptyAt[Int](0).contains(None))
+  }
+
+  pureTest("Row.asNonEmptyAt should return decoded value for non-empty cells") {
+    val row = Row(NonEmptyList.of("", "2", "3"))
+    expect(row.asNonEmptyAt[Int](1).contains(Some(2)))
+  }
 }


### PR DESCRIPTION
Add a way to, when working with rows directly, deal comfortably with optional cell values. New methods on `RowF` added instead of automatically deriving `CellDecoder` instances for `Option` to not interfere with generic derivation of row decoders and to capture user intent better.