### PR TITLE
Clean up type params

### DIFF
--- a/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/DerivedCsvRowDecoder.scala
+++ b/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/DerivedCsvRowDecoder.scala
@@ -28,7 +28,7 @@ object DerivedCsvRowDecoder {
       gen: LabelledGeneric.Aux[T, Repr],
       defaults: Default.AsOptions.Aux[T, DefaultRepr],
       annotations: Annotations.Aux[CsvName, T, AnnoRepr],
-      cc: Lazy[MapShapedCsvRowDecoder.WithDefaults[T, Repr, DefaultRepr, AnnoRepr]]): DerivedCsvRowDecoder[T] =
+      cc: Lazy[MapShapedCsvRowDecoder.WithDefaults[Repr, DefaultRepr, AnnoRepr]]): DerivedCsvRowDecoder[T] =
     new DerivedCsvRowDecoder[T] {
       def apply(row: CsvRow[String]): DecoderResult[T] =
         cc.value.fromWithDefault(row, defaults(), annotations()).map(gen.from(_))

--- a/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/DerivedCsvRowEncoder.scala
+++ b/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/DerivedCsvRowEncoder.scala
@@ -27,7 +27,7 @@ object DerivedCsvRowEncoder {
   final implicit def productWriter[T, Repr <: HList, AnnoRepr <: HList](implicit
       gen: LabelledGeneric.Aux[T, Repr],
       annotations: Annotations.Aux[CsvName, T, AnnoRepr],
-      cc: Lazy[MapShapedCsvRowEncoder.WithAnnotations[T, Repr, AnnoRepr]]): DerivedCsvRowEncoder[T] =
+      cc: Lazy[MapShapedCsvRowEncoder.WithAnnotations[Repr, AnnoRepr]]): DerivedCsvRowEncoder[T] =
     (elem: T) => cc.value.fromWithAnnotation(gen.to(elem), annotations())
 
 }

--- a/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/MapShapedCsvRowDecoder.scala
+++ b/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/MapShapedCsvRowDecoder.scala
@@ -26,31 +26,20 @@ trait MapShapedCsvRowDecoder[Repr] extends CsvRowDecoder[Repr, String]
 
 object MapShapedCsvRowDecoder extends LowPriorityMapShapedCsvRowDecoder1 {
 
-  implicit def hnilRowDecoder[Wrapped]: WithDefaults[Wrapped, HNil, HNil, HNil] =
-    new WithDefaults[Wrapped, HNil, HNil, HNil] {
+  implicit val hnilRowDecoder: WithDefaults[HNil, HNil, HNil] =
+    new WithDefaults[HNil, HNil, HNil] {
       def fromWithDefault(row: CsvRow[String], default: HNil, annotation: HNil): DecoderResult[HNil] =
         Right(HNil)
     }
 
-  implicit def optionHconsRowDecoder[Wrapped,
-                                     Key <: Symbol,
-                                     Head,
-                                     Tail <: HList,
-                                     DefaultTail <: HList,
-                                     Anno,
-                                     AnnoTail <: HList](implicit
+  implicit def optionHconsRowDecoder[Key <: Symbol, Head, Tail <: HList, DefaultTail <: HList, Anno, AnnoTail <: HList](
+      implicit
       witness: Witness.Aux[Key],
       Head: CellDecoder[Head],
       ev: <:<[Anno, Option[CsvName]],
-      Tail: Lazy[WithDefaults[Wrapped, Tail, DefaultTail, AnnoTail]])
-      : WithDefaults[Wrapped,
-                     FieldType[Key, Option[Head]] :: Tail,
-                     Option[Option[Head]] :: DefaultTail,
-                     Anno :: AnnoTail] =
-    new WithDefaults[Wrapped,
-                     FieldType[Key, Option[Head]] :: Tail,
-                     Option[Option[Head]] :: DefaultTail,
-                     Anno :: AnnoTail] {
+      Tail: Lazy[WithDefaults[Tail, DefaultTail, AnnoTail]])
+      : WithDefaults[FieldType[Key, Option[Head]] :: Tail, Option[Option[Head]] :: DefaultTail, Anno :: AnnoTail] =
+    new WithDefaults[FieldType[Key, Option[Head]] :: Tail, Option[Option[Head]] :: DefaultTail, Anno :: AnnoTail] {
       def fromWithDefault(row: CsvRow[String],
                           default: Option[Option[Head]] :: DefaultTail,
                           anno: Anno :: AnnoTail): DecoderResult[FieldType[Key, Option[Head]] :: Tail] = {
@@ -69,23 +58,18 @@ object MapShapedCsvRowDecoder extends LowPriorityMapShapedCsvRowDecoder1 {
 
 private[generic] trait LowPriorityMapShapedCsvRowDecoder1 {
 
-  trait WithDefaults[Wrapped, Repr, DefaultRepr, AnnoRepr] {
+  trait WithDefaults[Repr, DefaultRepr, AnnoRepr] {
     def fromWithDefault(row: CsvRow[String], default: DefaultRepr, annotation: AnnoRepr): DecoderResult[Repr]
   }
 
-  implicit def hconsRowDecoder[Wrapped,
-                               Key <: Symbol,
-                               Head,
-                               Tail <: HList,
-                               DefaultTail <: HList,
-                               Anno,
-                               AnnoTail <: HList](implicit
+  implicit def hconsRowDecoder[Key <: Symbol, Head, Tail <: HList, DefaultTail <: HList, Anno, AnnoTail <: HList](
+      implicit
       witness: Witness.Aux[Key],
       Head: CellDecoder[Head],
       ev: <:<[Anno, Option[CsvName]],
-      Tail: Lazy[WithDefaults[Wrapped, Tail, DefaultTail, AnnoTail]])
-      : WithDefaults[Wrapped, FieldType[Key, Head] :: Tail, Option[Head] :: DefaultTail, Anno :: AnnoTail] =
-    new WithDefaults[Wrapped, FieldType[Key, Head] :: Tail, Option[Head] :: DefaultTail, Anno :: AnnoTail] {
+      Tail: Lazy[WithDefaults[Tail, DefaultTail, AnnoTail]])
+      : WithDefaults[FieldType[Key, Head] :: Tail, Option[Head] :: DefaultTail, Anno :: AnnoTail] =
+    new WithDefaults[FieldType[Key, Head] :: Tail, Option[Head] :: DefaultTail, Anno :: AnnoTail] {
       def fromWithDefault(row: CsvRow[String],
                           default: Option[Head] :: DefaultTail,
                           anno: Anno :: AnnoTail): DecoderResult[FieldType[Key, Head] :: Tail] = {


### PR DESCRIPTION
Turns out we don't have to track the type of the case class we're deriving for while deriving the corresponding HList codec. MiMa seems happy as the only changes are type parameters and I don't expect users to ever call the affected methods from their code, so it's source-compatible.