### PR TITLE
Make header type classes easier to use

### DIFF
--- a/csv/shared/src/main/scala/fs2/data/csv/ParseableHeader.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/ParseableHeader.scala
@@ -34,6 +34,10 @@ object ParseableHeader {
   def apply[Header: ParseableHeader]: ParseableHeader[Header] =
     implicitly[ParseableHeader[Header]]
 
+  /**
+    * Define an instance of [[ParseableHeader]] that decodes each column individually using the provided
+    * `parse` function.
+    */
   def instance[Header](parse: String => Either[HeaderError, Header]): ParseableHeader[Header] =
     _.traverse[Either[HeaderError, *], Header](parse)
 

--- a/csv/shared/src/main/scala/fs2/data/csv/ParseableHeader.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/ParseableHeader.scala
@@ -34,6 +34,9 @@ object ParseableHeader {
   def apply[Header: ParseableHeader]: ParseableHeader[Header] =
     implicitly[ParseableHeader[Header]]
 
+  def instance[Header](parse: String => Either[HeaderError, Header]): ParseableHeader[Header] =
+    _.traverse[Either[HeaderError, *], Header](parse)
+
   implicit object NothingParseableHeader extends ParseableHeader[Nothing] {
     def apply(names: NonEmptyList[String]): HeaderResult[Nothing] =
       new HeaderError("no headers are expected").asLeft[NonEmptyList[Nothing]]

--- a/csv/shared/src/main/scala/fs2/data/csv/WriteableHeader.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/WriteableHeader.scala
@@ -29,6 +29,10 @@ object WriteableHeader {
   def apply[Header: WriteableHeader]: WriteableHeader[Header] =
     implicitly[WriteableHeader[Header]]
 
+  /**
+    * Define an instance of [[WriteableHeader]] that encodes each column individually using the provided
+    * `encode` function.
+    */
   def instance[Header](encode: Header => String): WriteableHeader[Header] =
     _.map(encode)
 

--- a/csv/shared/src/main/scala/fs2/data/csv/WriteableHeader.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/WriteableHeader.scala
@@ -29,6 +29,9 @@ object WriteableHeader {
   def apply[Header: WriteableHeader]: WriteableHeader[Header] =
     implicitly[WriteableHeader[Header]]
 
+  def instance[Header](encode: Header => String): WriteableHeader[Header] =
+    _.map(encode)
+
   implicit object StringWriteableHeader extends WriteableHeader[String] {
     def apply(names: NonEmptyList[String]): NonEmptyList[String] = names
   }

--- a/documentation/docs/csv/index.md
+++ b/documentation/docs/csv/index.md
@@ -132,14 +132,8 @@ object MyHeaders extends Enum[MyHeaders] {
   def values = findValues
 }
 
-implicit object ParseableMyHeaders extends ParseableHeader[MyHeaders] {
-  def apply(names: NonEmptyList[String]): HeaderResult[MyHeaders] =
-    names.traverse { name =>
-      MyHeaders.withNameInsensitiveOption(name) match {
-        case Some(headers) => Right(headers)
-        case None          => Left(new HeaderError(s"Unknown header $name"))
-      }
-    }
+implicit val parseableMyHeaders: ParseableHeader[MyHeaders] = ParseableHeader.instance[MyHeaders] { name =>
+   MyHeaders.withNameInsensitiveOption(name).toRight(new HeaderError(s"Unknown header $name"))
 }
 
 val withMyHeaders = stream.through(lowlevel.headers[Fallible, MyHeaders])


### PR DESCRIPTION
Add helpers for the common case where you want to decode or encode headers one by one.