### PR TITLE
Add regular language implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,9 +44,7 @@ val commonSettings = List(
     "io.circe" %%% "circe-generic" % circeVersion % "test",
     "co.fs2" %%% "fs2-io" % fs2Version % "test",
     "com.disneystreaming" %%% "weaver-cats" % weaverVersion % "test",
-    "com.disneystreaming" %%% "weaver-cats-core" % weaverVersion % "test",
-    "com.disneystreaming" %%% "weaver-core" % weaverVersion % "test",
-    "com.disneystreaming" %%% "weaver-framework" % weaverVersion % "test",
+    "com.disneystreaming" %%% "weaver-scalacheck" % weaverVersion % Test,
     "com.eed3si9n.expecty" %%% "expecty" % "0.16.0" % "test",
     "org.portable-scala" %%% "portable-scala-reflect" % "1.1.2" cross CrossVersion.for3Use2_13
   ) ++ PartialFunction

--- a/finite-state/shared/src/main/scala/fs2/data/pfsa/Candidate.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/pfsa/Candidate.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.pfsa
+
+trait Candidate[Set, C] {
+
+  def pick(set: Set): Option[C]
+
+}

--- a/finite-state/shared/src/main/scala/fs2/data/pfsa/Pred.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/pfsa/Pred.scala
@@ -47,6 +47,13 @@ object Pred {
   def apply[P, T](implicit ev: Pred[P, T]): Pred[P, T] = ev
 
   object syntax {
+
+    def always[P](implicit P: Pred[P, _]): P =
+      P.always
+
+    def never[P](implicit P: Pred[P, _]): P =
+      P.never
+
     implicit class PredOps[P](val p1: P) extends AnyVal {
       def satisfies[Elt](e: Elt)(implicit P: Pred[P, Elt]): Boolean =
         P.satsifies(p1)(e)

--- a/finite-state/shared/src/main/scala/fs2/data/pfsa/Regular.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/pfsa/Regular.scala
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2022 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.pfsa
+
+import cats.data.Chain
+import cats.syntax.all._
+import cats.{Eq, Show}
+
+import Pred.syntax._
+
+/** Simple regular language with character sets.
+  * This allows to model simple query languages (think XPath or JsonPath)
+  * and derive DFA out of it.
+  */
+sealed abstract class Regular[CharSet] {
+
+  def ~(that: Regular[CharSet])(implicit CharSet: Pred[CharSet, _], eq: Eq[CharSet]): Regular[CharSet] =
+    (this, that) match {
+      case (Regular.Epsilon(), _)               => that
+      case (_, Regular.Epsilon())               => this
+      case (Regular.Concatenation(re1, re2), _) => re1 ~ (re2 ~ that)
+      case (_, _) =>
+        if (this.isSatisfiable && that.isSatisfiable)
+          Regular.Concatenation(this, that)
+        else
+          Regular.empty
+    }
+
+  def &&(that: Regular[CharSet])(implicit CharSet: Pred[CharSet, _], eq: Eq[CharSet]): Regular[CharSet] =
+    (this, that) match {
+      case (Regular.And(re1, re2), _) => re1 && (re2 && that)
+      case (_, _) =>
+        if (this === that)
+          this
+        else if (this === Regular.any)
+          that
+        else if (that === Regular.any)
+          this
+        else if (this.isSatisfiable && that.isSatisfiable)
+          Regular.And(this, that)
+        else
+          Regular.empty
+    }
+
+  def ||(that: Regular[CharSet])(implicit CharSet: Pred[CharSet, _], eq: Eq[CharSet]): Regular[CharSet] =
+    (this, that) match {
+      case (Regular.Or(re1, re2), _)                => re1 || (re2 || that)
+      case (Regular.Chars(cs1), Regular.Chars(cs2)) => Regular.Chars(cs1 || cs2)
+      case (_, _) =>
+        if (this === that)
+          this
+        else if (this === Regular.any)
+          Regular.any
+        else if (that === Regular.any)
+          Regular.any
+        else if (!this.isSatisfiable)
+          that
+        else if (!that.isSatisfiable)
+          this
+        else
+          Regular.Or(this, that)
+    }
+
+  def unary_!(implicit CharSet: Pred[CharSet, _], eq: Eq[CharSet]): Regular[CharSet] =
+    this match {
+      case Regular.Not(re)   => re
+      case Regular.Chars(cs) => Regular.Chars(!cs)
+      case Regular.Epsilon() => Regular.any
+      case _ =>
+        if (this === Regular.any)
+          Regular.empty
+        else if (this === Regular.empty)
+          Regular.any
+        else
+          Regular.Not(this)
+    }
+
+  def rep(implicit CharSet: Pred[CharSet, _], eq: Eq[CharSet]): Regular[CharSet] =
+    this match {
+      case Regular.Star(_) => this
+      case _ =>
+        if (this === Regular.epsilon)
+          Regular.epsilon
+        else if (this === Regular.empty)
+          Regular.epsilon
+        else
+          Regular.Star(this)
+
+    }
+
+  def acceptEpsilon: Boolean =
+    this match {
+      case Regular.Epsilon()               => true
+      case Regular.Star(_)                 => true
+      case Regular.Or(re1, re2)            => re1.acceptEpsilon || re2.acceptEpsilon
+      case Regular.And(re1, re2)           => re1.acceptEpsilon && re2.acceptEpsilon
+      case Regular.Concatenation(re1, re2) => re1.acceptEpsilon && re2.acceptEpsilon
+      case Regular.Chars(_)                => false
+      case Regular.Not(re)                 => !re.acceptEpsilon
+    }
+
+  def derive[C](c: C)(implicit CharSet: Pred[CharSet, C], eq: Eq[CharSet]): Regular[CharSet] =
+    this match {
+      case Regular.Epsilon()                               => Regular.Chars(CharSet.never)
+      case Regular.Chars(set) if CharSet.satsifies(set)(c) => Regular.Epsilon()
+      case Regular.Chars(_)                                => Regular.Chars(CharSet.never)
+      case Regular.Concatenation(re1, re2) if re1.acceptEpsilon =>
+        (re1.derive(c) ~ re2) || re2.derive(c)
+      case Regular.Concatenation(re1, re2) =>
+        re1.derive(c) ~ re2
+      case Regular.Or(re1, re2) =>
+        re1.derive(c) || re2.derive(c)
+      case Regular.And(re1, re2) =>
+        re1.derive(c) && re2.derive(c)
+      case Regular.Star(re) =>
+        re.derive(c) ~ Regular.Star(re)
+      case Regular.Not(re) =>
+        !re.derive(c)
+    }
+
+  def classes[C](implicit CharSet: Pred[CharSet, C]): Set[CharSet] =
+    this match {
+      case Regular.Epsilon()                                    => Set(CharSet.always)
+      case Regular.Chars(chars)                                 => Set(chars, CharSet.not(chars))
+      case Regular.Concatenation(re1, re2) if re1.acceptEpsilon => combine(re1.classes, re2.classes)
+      case Regular.Concatenation(re1, _)                        => re1.classes
+      case Regular.Or(re1, re2)                                 => combine(re1.classes, re2.classes)
+      case Regular.And(re1, re2)                                => combine(re1.classes, re2.classes)
+      case Regular.Star(re)                                     => re.classes
+      case Regular.Not(re)                                      => re.classes
+    }
+
+  private def combine[C](c1: Set[CharSet], c2: Set[CharSet])(implicit CharSet: Pred[CharSet, C]): Set[CharSet] =
+    for {
+      cs1 <- c1
+      cs2 <- c2
+      both = CharSet.and(cs1, cs2)
+      if CharSet.isSatisfiable(both)
+    } yield both
+
+  def deriveDFA[C](implicit
+      CharSet: Pred[CharSet, C],
+      candidate: Candidate[CharSet, C],
+      eq: Eq[CharSet]): PDFA[CharSet, C] = {
+
+    def goto(re: Regular[CharSet],
+             q: Int,
+             cs: CharSet,
+             qs: Chain[Regular[CharSet]],
+             transitions: Map[Int, List[(CharSet, Int)]]): (Chain[Regular[CharSet]], Map[Int, List[(CharSet, Int)]]) =
+      candidate.pick(cs) match {
+        case Some(c) =>
+          val tgt = re.derive(c)
+          val equivalent = qs.zipWithIndex.collectFirst {
+            case (q, idx) if tgt === q => idx
+          }
+          equivalent match {
+            case Some(tgt) => (qs, transitions.combine(Map(q -> List(cs -> tgt))))
+            case None =>
+              val qs1 = qs.append(tgt)
+              val q1 = qs.size.toInt
+              val transitions1 = transitions.combine(Map(q -> List(cs -> q1)))
+              explore(qs1, transitions1, tgt)
+          }
+        case None =>
+          (qs, transitions)
+      }
+
+    def explore(qs: Chain[Regular[CharSet]],
+                transitions: Map[Int, List[(CharSet, Int)]],
+                re: Regular[CharSet]): (Chain[Regular[CharSet]], Map[Int, List[(CharSet, Int)]]) = {
+      val q = qs.size.toInt - 1
+      re.classes.foldLeft((qs, transitions)) { case ((qs, transitions), cs) =>
+        goto(re, q, cs, qs, transitions)
+      }
+    }
+
+    val (qs, transitions) = explore(Chain.one(this), Map.empty, this)
+    val finals = qs.zipWithIndex.collect { case (re, idx) if re.acceptEpsilon => idx }.toList.toSet
+    new PDFA[CharSet, C](0, finals, Array.tabulate(qs.size.toInt)(transitions.getOrElse(_, Nil)))
+  }
+
+}
+object Regular {
+  private case class Epsilon[CharSet]() extends Regular[CharSet]
+  private case class Chars[CharSet](set: CharSet) extends Regular[CharSet]
+  private case class Star[CharSet](re: Regular[CharSet]) extends Regular[CharSet]
+  private case class Concatenation[CharSet](re1: Regular[CharSet], re2: Regular[CharSet]) extends Regular[CharSet]
+  private case class Or[CharSet](re1: Regular[CharSet], re2: Regular[CharSet]) extends Regular[CharSet]
+  private case class And[CharSet](re1: Regular[CharSet], re2: Regular[CharSet]) extends Regular[CharSet]
+  private case class Not[CharSet](re: Regular[CharSet]) extends Regular[CharSet]
+
+  implicit def eq[CharSet: Eq]: Eq[Regular[CharSet]] = Eq.instance {
+    case (Epsilon(), Epsilon())                                 => true
+    case (Chars(cs1), Chars(cs2))                               => cs1 === cs2
+    case (Star(re1), Star(re2))                                 => re1 === re2
+    case (Concatenation(re11, re12), Concatenation(re21, re22)) => re11 === re21 && re12 === re22
+    case (Or(re11, re12), Or(re21, re22)) =>
+      (re11 === re21 && re12 === re22) || (re11 === re22 && re12 === re21)
+    case (And(re11, re12), And(re21, re22)) =>
+      (re11 === re21 && re12 === re22) || (re11 === re22 && re12 === re21)
+    case (Not(re1), Not(re2)) => re1 === re2
+    case _                    => false
+  }
+
+  def epsilon[CharSet]: Regular[CharSet] = Epsilon()
+
+  def chars[CharSet](cs: CharSet): Regular[CharSet] =
+    Regular.Chars(cs)
+
+  def any[CharSet](implicit CharSet: Pred[CharSet, _]): Regular[CharSet] = Chars(CharSet.always)
+
+  def empty[CharSet](implicit CharSet: Pred[CharSet, _]): Regular[CharSet] = Chars(CharSet.never)
+
+  implicit def pred[CharSet: Eq, C](implicit CharSet: Pred[CharSet, C]): Pred[Regular[CharSet], C] =
+    new Pred[Regular[CharSet], C] {
+
+      override def satsifies(p: Regular[CharSet])(e: C): Boolean =
+        p match {
+          case Epsilon()  => false
+          case Chars(set) => set.satisfies(e)
+          case Star(re)   => re.satisfies(e)
+          case Concatenation(re1, re2) =>
+            re1.satisfies(e) || (re1.acceptEpsilon && re2.satisfies(e))
+          case Or(re1, re2)  => re1.satisfies(e) || re2.satisfies(e)
+          case And(re1, re2) => re1.satisfies(e) && re2.satisfies(e)
+          case Not(re)       => !re.satisfies(e)
+        }
+
+      override def always: Regular[CharSet] = any
+
+      override def never: Regular[CharSet] = empty
+
+      override def and(p1: Regular[CharSet], p2: Regular[CharSet]): Regular[CharSet] = p1 && p2
+
+      override def or(p1: Regular[CharSet], p2: Regular[CharSet]): Regular[CharSet] = p1 || p2
+
+      override def not(p: Regular[CharSet]): Regular[CharSet] = !p
+
+      override def isSatisfiable(p: Regular[CharSet]): Boolean = p =!= empty
+
+    }
+
+  implicit def show[CS: Show]: Show[Regular[CS]] = Show.show {
+    case Epsilon()               => "ε"
+    case Chars(cs)               => cs.show
+    case Concatenation(re1, re2) => show"$re1$re2"
+    case Or(re1, re2)            => show"($re1) | ($re2)"
+    case And(re1, re2)           => show"($re1) & ($re2)"
+    case Star(re)                => show"($re)*"
+    case Not(re)                 => show"~($re)"
+  }
+}

--- a/finite-state/shared/src/test/scala/fs2/data/pfsa/RegularSpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/pfsa/RegularSpec.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.pfsa
+
+import cats.Show
+import org.scalacheck.{Arbitrary, Gen}
+import weaver._
+import weaver.scalacheck._
+
+import Regular._
+
+object RegularSpec extends SimpleIOSuite with Checkers {
+
+  type Regex = Regular[Set[Char]]
+
+  implicit val charSetShow: Show[Set[Char]] = Show.show { set =>
+    if (set.size <= 1)
+      set.headOption.fold("∅")(_.toString())
+    else
+      set.toList.sorted.mkString("[", "", "]")
+
+  }
+
+  implicit val arbitraryChar: Arbitrary[Char] = Arbitrary(Gen.oneOf('a', 'b'))
+
+  implicit object CharSetInstances extends Pred[Set[Char], Char] with Candidate[Set[Char], Char] {
+
+    override def satsifies(p: Set[Char])(e: Char): Boolean = p.contains(e)
+
+    override val always: Set[Char] = Set('a', 'b')
+
+    override val never: Set[Char] = Set.empty
+
+    override def and(p1: Set[Char], p2: Set[Char]): Set[Char] = p1.intersect(p2)
+
+    override def or(p1: Set[Char], p2: Set[Char]): Set[Char] = p1.union(p2)
+
+    override def not(p: Set[Char]): Set[Char] = always.diff(p)
+
+    override def isSatisfiable(p: Set[Char]): Boolean = p.nonEmpty
+
+    override def pick(set: Set[Char]): Option[Char] = set.headOption
+
+  }
+
+  test("empty") {
+    val dfa = empty.deriveDFA
+    forall(Gen.listOf(arbitraryChar.arbitrary)) { input =>
+      expect.eql(false, dfa.recognizes(input))
+    }
+  }
+
+  test("epsilon") {
+    val dfa = epsilon.deriveDFA
+    forall(Gen.listOf(arbitraryChar.arbitrary)) { input =>
+      expect.eql(input.isEmpty, dfa.recognizes(input))
+    }
+  }
+
+  test("any") {
+    val dfa = any.deriveDFA
+    forall(Gen.listOf(arbitraryChar.arbitrary)) { input =>
+      expect.eql(input.size == 1, dfa.recognizes(input))
+    }
+  }
+
+  test("any1") {
+    val dfa = any.deriveDFA
+    forall(Gen.listOfN(1, arbitraryChar.arbitrary)) { input =>
+      expect.eql(true, dfa.recognizes(input))
+    }
+  }
+
+  test("chars") {
+    val gen =
+      for {
+        set <- Gen.listOf(arbitraryChar.arbitrary).map(_.toSet)
+        c <- arbitraryChar.arbitrary
+      } yield (set, c)
+    forall(gen) { case (set, c) =>
+      val dfa = chars(set).deriveDFA
+      expect.eql(set.contains(c), dfa.recognizes(List(c)))
+    }
+  }
+
+  pureTest("complex") {
+    val dfa =
+      ((chars(Set('a', 'b')) ~ chars(Set('a'))) || (chars(Set('b')).rep ~ !epsilon)).deriveDFA
+    expect.all(dfa.recognizes("aa".toList),
+               dfa.recognizes("ba".toList),
+               dfa.recognizes("bbb".toList),
+               dfa.recognizes("a".toList),
+               !dfa.recognizes("".toList))
+  }
+
+}

--- a/finite-state/shared/src/test/scala/fs2/data/pfsa/package.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/pfsa/package.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data
+
+import cats.Eq
+import org.scalacheck.{Arbitrary, Gen}
+
+package object pfsa {
+
+  implicit def arbRegular[CS: Eq, C](implicit a: Arbitrary[CS], CS: Pred[CS, C]): Arbitrary[Regular[CS]] =
+    Arbitrary {
+      val genLeaf: Gen[Regular[CS]] = Gen.oneOf(Gen.const(Regular.any),
+                                                Gen.const(Regular.epsilon[CS]),
+                                                Gen.const(Regular.empty),
+                                                a.arbitrary.map(Regular.chars(_)))
+
+      def genInternal(sz: Int): Gen[Regular[CS]] =
+        Gen.oneOf(
+          for {
+            lsz <- Gen.choose(sz - 3, sz - 1)
+            l <- sizedRegular(lsz)
+            rsz <- Gen.choose(sz / 3, sz / 2)
+            r <- sizedRegular(rsz)
+            const <- Gen.oneOf[Regular[CS] => Regular[CS]](l && _, l || _, l ~ _)
+          } yield const(r),
+          for {
+            sz <- Gen.choose(sz / 3, sz / 2)
+            re <- sizedRegular(sz)
+          } yield !re
+        )
+
+      def sizedRegular(sz: Int) =
+        if (sz <= 0) genLeaf
+        else Gen.frequency((1, genLeaf), (3, genInternal(sz)))
+
+      Gen.sized(sz => sizedRegular(sz))
+    }
+}


### PR DESCRIPTION
Based on regular expression derivation with character classes, generalized to predicates, this allows to have a generic direct DFA construction algorithm for any regular language.

This allows to share implementation between several query languages (XPath and JsonPath might also be rewritten to use this representation instead of computing the NFA first).

Implementation is based on the paper [_Regular-expression derivatives reexamined_](https://www.ccs.neu.edu/home/turon/re-deriv.pdf)