### PR TITLE
Add tree query compiler implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -443,7 +443,33 @@ lazy val finiteState = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "fs2-data-finite-state",
     description := "Streaming finite state machines",
-    tlVersionIntroduced := Map("3" -> "1.6.0", "2.13" -> "1.6.0", "2.12" -> "1.6.0")
+    tlVersionIntroduced := Map("3" -> "1.6.0", "2.13" -> "1.6.0", "2.12" -> "1.6.0"),
+    mimaBinaryIssueFilters ++= List(
+      // all filters related to esp.Rhs.Captured* come from converting it from case class to case object
+      ProblemFilters.exclude[MissingClassProblem]("fs2.data.esp.Rhs$CapturedLeaf"),
+      ProblemFilters.exclude[MissingTypesProblem]("fs2.data.esp.Rhs$CapturedLeaf$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.esp.Rhs#CapturedLeaf.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.esp.Rhs#CapturedLeaf.unapply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.esp.Rhs#CapturedTree.name"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.esp.Rhs#CapturedTree.copy"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.data.esp.Rhs#CapturedTree.copy$default$1"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.esp.Rhs#CapturedTree.copy$default$2"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.esp.Rhs#CapturedTree.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.esp.Rhs#CapturedTree.apply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.data.esp.Rhs#CapturedLeaf.fromProduct"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.data.esp.Rhs#CapturedTree._1"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.esp.Rhs#CapturedTree._2"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "fs2.data.mft.MFTBuilder#Guardable.fs2$data$mft$MFTBuilder$Guardable$$$outer"),
+      // rules now only have number of parameters
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.data.mft.Rules.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.mft.Rules.params"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.data.mft.Rules.copy"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.data.mft.Rules.copy$default$1"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.data.mft.Rules.this"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.data.mft.Rules.apply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.data.mft.Rules._1")
+    )
   )
   .jsSettings(
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,13 @@ val commonSettings = List(
   scalacOptions := scalacOptions.value.filterNot(_ == "-source:3.0-migration"),
   scalacOptions ++= PartialFunction
     .condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
+      case Some((2, _)) => List("-Ypatmat-exhaust-depth", "40")
+      case _            => Nil
+    }
+    .toList
+    .flatten,
+  scalacOptions ++= PartialFunction
+    .condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
       case Some((2, 12)) =>
         List(
           "-Wconf:msg=it is not recommended to define classes/objects inside of package objects:s",
@@ -437,6 +444,9 @@ lazy val finiteState = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     name := "fs2-data-finite-state",
     description := "Streaming finite state machines",
     tlVersionIntroduced := Map("3" -> "1.6.0", "2.13" -> "1.6.0", "2.12" -> "1.6.0")
+  )
+  .jsSettings(
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
   )
   .nativeSettings(
     tlVersionIntroduced := Map("3" -> "1.5.1", "2.13" -> "1.5.1", "2.12" -> "1.5.1")

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.tools.mima.core._
 
 val scala212 = "2.12.17"
-val scala213 = "2.13.8"
+val scala213 = "2.13.10"
 val scala3 = "3.2.1"
 val fs2Version = "3.4.0"
 val circeVersion = "0.14.3"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.tools.mima.core._
 
 val scala212 = "2.12.17"
-val scala213 = "2.13.10"
+val scala213 = "2.13.8"
 val scala3 = "3.2.1"
 val fs2Version = "3.4.0"
 val circeVersion = "0.14.3"

--- a/finite-state/shared/src/main/scala/fs2/data/esp/ESP.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/ESP.scala
@@ -100,7 +100,7 @@ private[data] class ESP[F[_], Guard, InTag, OutTag](init: Int,
       case Rhs.SelfCall(q, params) =>
         params
           .traverse(eval(env, depth, in, _))
-          .flatMap(params => call(env, q, 0, params, in))
+          .flatMap(call(env, q, 0, _, in))
       case Rhs.Param(i) =>
         env
           .get(i)

--- a/finite-state/shared/src/main/scala/fs2/data/esp/ESP.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/ESP.scala
@@ -125,7 +125,7 @@ private[data] class ESP[F[_], Guard, InTag, OutTag](init: Int,
         in.flatMap(select(_, Selector.Cons(Selector.Root(), Tag.Leaf, 0)))
           .liftTo[Pull[F, Nothing, *]](new ESPException("cannot capture eos"))
           .map(v => Expr.Leaf(Out.makeLeaf(TT.convert(v)), Expr.Epsilon))
-      case Rhs.ApplyToLeaf(f: (OutTag => Either[String, OutTag])) =>
+      case Rhs.ApplyToLeaf(f: (OutTag => Either[String, OutTag]) @unchecked) =>
         in.flatMap(select(_, Selector.Cons(Selector.Root(), Tag.Leaf, 0)))
           .liftTo[Pull[F, Nothing, *]](new ESPException("cannot capture eos"))
           .flatMap(v =>

--- a/finite-state/shared/src/main/scala/fs2/data/esp/ESP.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/ESP.scala
@@ -30,7 +30,7 @@ import scala.annotation.tailrec
   * catch all rules, no matter what the state or depth is.
   */
 private[data] class ESP[F[_], Guard, InTag, OutTag](init: Int,
-                                                    val params: Map[Int, List[Int]],
+                                                    val params: Map[Int, Int],
                                                     val rules: DecisionTree[Guard, Tag[InTag], Rhs[OutTag]])(implicit
     F: RaiseThrowable[F]) {
 
@@ -40,9 +40,8 @@ private[data] class ESP[F[_], Guard, InTag, OutTag](init: Int,
       TT: Tag2Tag[InTag, OutTag],
       G: Evaluator[Guard, Tag[InTag]]) =
     params.get(q).liftTo[Pull[F, Nothing, *]](new ESPException(s"unknown state $q")).flatMap { params =>
-      if (params.size === args.size) {
-        args
-          .zip(params)
+      if (params === args.size) {
+        args.zipWithIndex
           .foldLeftM(env) { case (env, (arg, param)) =>
             step(env, arg, in).map { rhs =>
               env.updated(param, rhs)
@@ -56,7 +55,7 @@ private[data] class ESP[F[_], Guard, InTag, OutTag](init: Int,
           }
       } else {
         Pull.raiseError(new ESPException(
-          s"wrong number of argument given in state $q reading input $in (expected ${params.size} but got ${args.size})"))
+          s"wrong number of argument given in state $q reading input $in (expected $params but got ${args.size})"))
       }
     }
 
@@ -111,7 +110,7 @@ private[data] class ESP[F[_], Guard, InTag, OutTag](init: Int,
       case Rhs.Tree(tag, inner) =>
         eval(env, depth, in, inner)
           .map(inner => Expr.Open(Out.makeOpen(tag), Expr.concat(inner, Expr.Close(Out.makeClose(tag), Expr.Epsilon))))
-      case Rhs.CapturedTree(_, inner) =>
+      case Rhs.CapturedTree(inner) =>
         eval(env, depth, in, inner).flatMap { inner =>
           in.flatMap(select(_, Selector.Cons(Selector.Root(), Tag.Open, 0)))
             .liftTo[Pull[F, Nothing, *]](new ESPException("cannot capture eos"))
@@ -122,7 +121,7 @@ private[data] class ESP[F[_], Guard, InTag, OutTag](init: Int,
         }
       case Rhs.Leaf(v) =>
         Pull.pure(Expr.Leaf(Out.makeLeaf(v), Expr.Epsilon))
-      case Rhs.CapturedLeaf(_) =>
+      case Rhs.CapturedLeaf =>
         in.flatMap(select(_, Selector.Cons(Selector.Root(), Tag.Leaf, 0)))
           .liftTo[Pull[F, Nothing, *]](new ESPException("cannot capture eos"))
           .map(v => Expr.Leaf(Out.makeLeaf(TT.convert(v)), Expr.Epsilon))
@@ -181,8 +180,9 @@ private[data] class ESP[F[_], Guard, InTag, OutTag](init: Int,
         case None =>
           step(env, e, none).map(squeezeAll(_)).flatMap { case (e, s) =>
             e match {
-              case Expr.Epsilon => Pull.output(Chunk.seq(s))
-              case _            => Pull.raiseError(new ESPException(s"unexpected end of input $e"))
+              case Expr.Epsilon =>
+                Pull.output(Chunk.seq(s))
+              case _ => Pull.raiseError(new ESPException(s"unexpected end of input $e"))
             }
           }
       }
@@ -197,6 +197,6 @@ private[data] class ESP[F[_], Guard, InTag, OutTag](init: Int,
       Out: Conversion[OutTag, Out],
       TT: Tag2Tag[InTag, OutTag],
       G: Evaluator[Guard, Tag[InTag]]): Pipe[F, In, Out] =
-    transform(Chunk.empty, 0, _, Map.empty, Expr.Call(init, 0, Nil), new ListBuffer).stream
+    transform[In, Out](Chunk.empty, 0, _, Map.empty, Expr.Call(init, 0, Nil), new ListBuffer).stream
 
 }

--- a/finite-state/shared/src/main/scala/fs2/data/esp/Expr.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/Expr.scala
@@ -16,6 +16,10 @@
 
 package fs2.data.esp
 
+import cats.Show
+import cats.syntax.foldable._
+import cats.syntax.show._
+
 sealed trait Expr[+Out]
 object Expr {
   case class Call[Out](q: Int, depth: Int, params: List[Expr[Out]]) extends Expr[Out]
@@ -34,4 +38,13 @@ object Expr {
       case (Leaf(v, Epsilon), _)  => Leaf(v, e2)
       case (_, _)                 => Concat(e1, e2)
     }
+
+  implicit def show[Out: Show]: Show[Expr[Out]] = Show.show {
+    case Call(q, d, ps) => show"q${q}_$d(${ps.mkString_(", ")})"
+    case Epsilon        => ""
+    case Open(o, next)  => show"$o $next"
+    case Close(c, next) => show"$c $next"
+    case Leaf(l, next)  => show"$l $next"
+    case Concat(e1, e2) => show"$e1 $e2"
+  }
 }

--- a/finite-state/shared/src/main/scala/fs2/data/esp/Expr.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/Expr.scala
@@ -40,7 +40,7 @@ object Expr {
     }
 
   implicit def show[Out: Show]: Show[Expr[Out]] = Show.show {
-    case Call(q, d, ps) => show"q${q}_$d(${ps.mkString_(", ")})"
+    case Call(q, d, ps) => show"q${q}_$d(${(ps: List[Expr[Out]]).mkString_(", ")})"
     case Epsilon        => ""
     case Open(o, next)  => show"$o $next"
     case Close(c, next) => show"$c $next"

--- a/finite-state/shared/src/main/scala/fs2/data/esp/Rhs.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/Rhs.scala
@@ -41,13 +41,13 @@ object Rhs {
   case class Tree[OutTag](tag: OutTag, inner: Rhs[OutTag]) extends Rhs[OutTag]
 
   /** Builds a tree with the captured node tag in pattern. */
-  case class CapturedTree[OutTag](name: String, inner: Rhs[OutTag]) extends Rhs[OutTag]
+  case class CapturedTree[OutTag](inner: Rhs[OutTag]) extends Rhs[OutTag]
 
   /** Emits a leaf value. */
   case class Leaf[OutTag](value: OutTag) extends Rhs[OutTag]
 
   /** Emits the captured input value. */
-  case class CapturedLeaf(name: String) extends Rhs[Nothing]
+  case object CapturedLeaf extends Rhs[Nothing]
 
   /** Concatenates two RHS. */
   case class Concat[OutTag](fst: Rhs[OutTag], snd: Rhs[OutTag]) extends Rhs[OutTag]

--- a/finite-state/shared/src/main/scala/fs2/data/esp/Rhs.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/Rhs.scala
@@ -49,6 +49,9 @@ object Rhs {
   /** Emits the captured input value. */
   case object CapturedLeaf extends Rhs[Nothing]
 
+  /** Applies the function to a leaf value. */
+  case class ApplyToLeaf[OutTag](f: OutTag => Either[String, OutTag]) extends Rhs[OutTag]
+
   /** Concatenates two RHS. */
   case class Concat[OutTag](fst: Rhs[OutTag], snd: Rhs[OutTag]) extends Rhs[OutTag]
 

--- a/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
@@ -99,7 +99,7 @@ private[data] class MFT[Guard, InTag, OutTag](init: Int, val rules: Map[Int, Rul
         case Rhs.Node(_, children)  => bareOccurences(children)
         case Rhs.CopyNode(children) => bareOccurences(children)
         case Rhs.Concat(rhs1, rhs2) => bareOccurences(rhs1) ++ bareOccurences(rhs2)
-        case _                      => Set()
+        case _                      => Set.empty
       }
 
     def findAllCalls(rhs: Rhs[OutTag]): List[Rhs.Call[OutTag]] =
@@ -144,7 +144,7 @@ private[data] class MFT[Guard, InTag, OutTag](init: Int, val rules: Map[Int, Rul
                    x,
                    args.zipWithIndex
                      .collect {
-                       case (a, i) if allUsedParams.getOrElse(q, Set()).contains(i) =>
+                       case (a, i) if allUsedParams.getOrElse(q, Set.empty).contains(i) =>
                          dropUnused(a, usedParams)
                      })
         case Rhs.Node(tag, children) => Rhs.Node(tag, dropUnused(children, usedParams))
@@ -240,7 +240,7 @@ private[data] class MFT[Guard, InTag, OutTag](init: Int, val rules: Map[Int, Rul
         case Nil => processed
       }
 
-    val reachableStates = reachable(List(init), Set())
+    val reachableStates = reachable(List(init), Set.empty)
 
     new MFT(init, rules.filter { case (k, _) => reachableStates.contains(k) })
   }

--- a/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
@@ -24,7 +24,6 @@ import cats.{Defer, MonadError}
 import cats.syntax.all._
 import cats.Show
 import scala.annotation.tailrec
-import scala.collection.compat._
 
 sealed trait Forest
 object Forest {
@@ -243,7 +242,7 @@ private[data] class MFT[Guard, InTag, OutTag](init: Int, val rules: Map[Int, Rul
 
     val reachableStates = reachable(List(init), Set())
 
-    new MFT(init, rules.view.filterKeys(reachableStates.contains(_)).toMap)
+    new MFT(init, rules.filter { case (k, _) => reachableStates.contains(k) })
   }
 
   /** Compiles this MFT into an ESP.

--- a/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
@@ -64,6 +64,7 @@ object Rhs {
   case class CopyNode[OutTag](children: Rhs[OutTag]) extends Rhs[OutTag]
   case class Leaf[OutTag](value: OutTag) extends Rhs[OutTag]
   case object CopyLeaf extends Rhs[Nothing]
+  case class ApplyToLeaf[OutTag](f: OutTag => Either[String, OutTag]) extends Rhs[OutTag]
   case class Concat[OutTag](fst: Rhs[OutTag], snd: Rhs[OutTag]) extends Rhs[OutTag]
 
   implicit def show[O: Show]: Show[Rhs[O]] =
@@ -76,6 +77,7 @@ object Rhs {
       case CopyNode(children)  => show"%t($children)"
       case Leaf(value)         => show"<$value>"
       case CopyLeaf            => "%t"
+      case ApplyToLeaf(_)      => "<leaf-function>"
       case Concat(l, r)        => show"$l $r"
     }
 }
@@ -264,6 +266,7 @@ private[data] class MFT[Guard, InTag, OutTag](init: Int, val rules: Map[Int, Rul
         case Rhs.CopyNode(inner)                => ERhs.CapturedTree(translateRhs(inner))
         case Rhs.Leaf(v)                        => ERhs.Leaf(v)
         case Rhs.CopyLeaf                       => ERhs.CapturedLeaf
+        case Rhs.ApplyToLeaf(f)                 => ERhs.ApplyToLeaf(f)
         case Rhs.Concat(rhs1, rhs2)             => ERhs.Concat(translateRhs(rhs1), translateRhs(rhs2))
       }
 

--- a/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
@@ -41,7 +41,11 @@ object EventSelector {
 
 sealed trait Rhs[+OutTag] {
   def ~[OutTag1 >: OutTag](that: Rhs[OutTag1]): Rhs[OutTag1] =
-    Rhs.Concat(this, that)
+    (this, that) match {
+      case (Rhs.Epsilon, _) => that
+      case (_, Rhs.Epsilon) => this
+      case (_, _)           => Rhs.Concat(this, that)
+    }
 }
 object Rhs {
   case class Call[OutTag](q: Int, x: Forest, parameters: List[Rhs[OutTag]]) extends Rhs[OutTag]

--- a/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
@@ -163,7 +163,7 @@ object MFT {
           case EventSelector.Node(t, g) => show"(<$t>$params)${g.fold("")(g => show" when $g")}"
           case EventSelector.AnyLeaf(g) => show"(<%t />$params)${g.fold("")(g => show" when $g")}"
           case EventSelector.Leaf(t, g) => show"(<$t />$params)${g.fold("")(g => show" when $g")}"
-          case EventSelector.Epsilon()  => "(ε)"
+          case EventSelector.Epsilon()  => show"(ε$params)"
         }
         rules.tree
           .map { case (pat, rhs) =>

--- a/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
@@ -64,7 +64,7 @@ object Rhs {
   *
   * An MFT is an intermediate structure towards a compiled [[fs2.data.esp.ESP Events Stream Processor]]
   */
-private[data] class MFT[Guard, InTag, OutTag](init: Int, rules: Map[Int, Rules[Guard, InTag, OutTag]]) {
+private[data] class MFT[Guard, InTag, OutTag](init: Int, val rules: Map[Int, Rules[Guard, InTag, OutTag]]) {
 
   /** Compiles this MFT into an ESP.
     * The generated ESP contains one decision tree encoding all the patterns

--- a/finite-state/shared/src/main/scala/fs2/data/mft/MFTBuilder.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/MFTBuilder.scala
@@ -78,6 +78,6 @@ class MFTBuilder[Guard, InTag, OutTag] private[mft] {
   }
 
   def build: MFT[Guard, InTag, OutTag] =
-    new MFT(initial, states.map { st => st.q -> Rules(List.range(0, st.nargs), st.rules.result()) }.toMap)
+    new MFT(initial, states.map { st => st.q -> Rules(st.nargs, st.rules.result()) }.toMap)
 
 }

--- a/finite-state/shared/src/main/scala/fs2/data/mft/MFTBuilder.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/MFTBuilder.scala
@@ -37,6 +37,8 @@ class MFTBuilder[Guard, InTag, OutTag] private[mft] {
   sealed trait PatternBuilder
   sealed trait Guardable extends PatternBuilder {
     def when(guard: Guard): PatternBuilder
+    def when(guard: Option[Guard]): PatternBuilder =
+      guard.fold[PatternBuilder](this)(when(_))
   }
   private[mft] object PatternBuilder {
     case class Any(guard: Option[Guard]) extends Guardable {

--- a/finite-state/shared/src/main/scala/fs2/data/mft/Rules.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/Rules.scala
@@ -16,4 +16,9 @@
 
 package fs2.data.mft
 
-case class Rules[Guard, InTag, OutTag](nparams: Int, tree: List[(EventSelector[Guard, InTag], Rhs[OutTag])])
+case class Rules[Guard, InTag, OutTag](nparams: Int, tree: List[(EventSelector[Guard, InTag], Rhs[OutTag])]) {
+  def isWildcard: Boolean =
+    tree.map(_._1).toSet == Set(EventSelector.AnyLeaf(None),
+                                EventSelector.AnyNode(None),
+                                EventSelector.Epsilon()) && tree.map(_._2).toSet.size == 1
+}

--- a/finite-state/shared/src/main/scala/fs2/data/mft/Rules.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/Rules.scala
@@ -16,4 +16,4 @@
 
 package fs2.data.mft
 
-case class Rules[Guard, InTag, OutTag](params: List[Int], tree: List[(EventSelector[Guard, InTag], Rhs[OutTag])])
+case class Rules[Guard, InTag, OutTag](nparams: Int, tree: List[(EventSelector[Guard, InTag], Rhs[OutTag])])

--- a/finite-state/shared/src/main/scala/fs2/data/mft/package.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/package.scala
@@ -79,4 +79,7 @@ package object mft {
   def copy: Rhs[Nothing] =
     Rhs.CopyLeaf
 
+  def applyToLeaf[OutTag](f: OutTag => Either[String, OutTag]) =
+    Rhs.ApplyToLeaf(f)
+
 }

--- a/finite-state/shared/src/main/scala/fs2/data/mft/query/Query.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/query/Query.scala
@@ -34,4 +34,5 @@ object Query {
   case class Node[Tag, Path](tag: Tag, child: Query[Tag, Path]) extends Query[Tag, Path]
   case class Leaf[Tag, Path](tag: Tag) extends Query[Tag, Path]
   case class Sequence[Tag, Path](elements: NonEmptyList[Query[Tag, Path]]) extends Query[Tag, Path]
+  case class LeafFunction[Tag, Path](f: Tag => Either[String, Tag]) extends Query[Tag, Path]
 }

--- a/finite-state/shared/src/main/scala/fs2/data/mft/query/Query.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/query/Query.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fs2.data.mft.query
 
 import cats.data.NonEmptyList

--- a/finite-state/shared/src/main/scala/fs2/data/mft/query/Query.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/query/Query.scala
@@ -25,11 +25,13 @@ import cats.data.NonEmptyList
  */
 sealed trait Query[Tag, Path]
 object Query {
+  case class Empty[Tag, Path]() extends Query[Tag, Path]
   case class ForClause[Tag, Path](variable: String, source: Path, result: Query[Tag, Path]) extends Query[Tag, Path]
   case class LetClause[Tag, Path](variable: String, query: Query[Tag, Path], result: Query[Tag, Path])
       extends Query[Tag, Path]
   case class Ordpath[Tag, Path](path: Path) extends Query[Tag, Path]
   case class Variable[Tag, Path](name: String) extends Query[Tag, Path]
-  case class Element[Tag, Path](tag: Tag, child: Option[Query[Tag, Path]]) extends Query[Tag, Path]
+  case class Node[Tag, Path](tag: Tag, child: Query[Tag, Path]) extends Query[Tag, Path]
+  case class Leaf[Tag, Path](tag: Tag) extends Query[Tag, Path]
   case class Sequence[Tag, Path](elements: NonEmptyList[Query[Tag, Path]]) extends Query[Tag, Path]
 }

--- a/finite-state/shared/src/main/scala/fs2/data/mft/query/Query.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/query/Query.scala
@@ -1,0 +1,19 @@
+package fs2.data.mft.query
+
+import cats.data.NonEmptyList
+
+/* An abstract representation of query language that consists of
+ * nested for loops over some paths and tagged element construction.
+ *
+ * ''Note for implementers'': a path is always relative to the closes enclosing `for` clause.
+ */
+sealed trait Query[Tag, Path]
+object Query {
+  case class ForClause[Tag, Path](variable: String, source: Path, result: Query[Tag, Path]) extends Query[Tag, Path]
+  case class LetClause[Tag, Path](variable: String, query: Query[Tag, Path], result: Query[Tag, Path])
+      extends Query[Tag, Path]
+  case class Ordpath[Tag, Path](path: Path) extends Query[Tag, Path]
+  case class Variable[Tag, Path](name: String) extends Query[Tag, Path]
+  case class Element[Tag, Path](tag: Tag, child: Option[Query[Tag, Path]]) extends Query[Tag, Path]
+  case class Sequence[Tag, Path](elements: NonEmptyList[Query[Tag, Path]]) extends Query[Tag, Path]
+}

--- a/finite-state/shared/src/main/scala/fs2/data/mft/query/QueryCompiler.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/query/QueryCompiler.scala
@@ -113,9 +113,8 @@ private[fs2] abstract class QueryCompiler[Tag, Path] {
               if (!finalTgt) {
                 q1(pat.when(guard)) -> q2(x1, copyArgs: _*) ~ q1(x2, copyArgs: _*)
               } else {
-                q1(pat.when(guard)) -> end(x1, (copyArgs :+ copy(qcopy(x1))): _*) ~ q2(x1, copyArgs: _*) ~ q1(
-                  x2,
-                  copyArgs: _*)
+                q1(pat.when(guard)) -> end(x1, (copyArgs :+ copy(qcopy(x1))): _*) ~ q2(x1, copyArgs: _*) ~
+                  q1(x2, copyArgs: _*)
               }
               states1
             }

--- a/finite-state/shared/src/main/scala/fs2/data/mft/query/QueryCompiler.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/query/QueryCompiler.scala
@@ -1,0 +1,204 @@
+package fs2.data
+package mft
+package query
+
+import pfsa.{Candidate, Pred, Regular}
+import cats.Eq
+import cats.syntax.all._
+import cats.data.NonEmptyList
+import scala.annotation.tailrec
+
+/** This compiler can be used to compile to an MFT any query language that can be represented by nested for loops.
+  *
+  * The compiler is based on the approach described in [[https://doi.org/10.1109/ICDE.2014.6816714 _XQuery Streaming by Forest Transducers_]]
+  * and generalized for the abstract query language on trees.
+  */
+abstract class QueryCompiler[Tag, Path] {
+
+  type Matcher
+  type Pattern
+  type Guard
+
+  /** A single char to be matched in a path */
+  type Char
+
+  implicit def predicate: Pred[Matcher, Char]
+
+  implicit def candidate: Candidate[Matcher, Char]
+
+  implicit def charsEq: Eq[Matcher]
+
+  /** Creates a regular expression given a path. */
+  def path2regular(path: Path): Regular[Matcher]
+
+  /** Create (ordered) pattern matching cases with guards for a given matcher.
+    *
+    * Guard is expressed as a conjunction of atomic guard operations.
+    * If a case has no guard, returns an empty list for this case.
+    *
+    * Cases will be matched in ordered, the first matching case will be taken.
+    */
+  def cases(matcher: Matcher): List[(Pattern, List[Guard])]
+
+  /** Return the constructor tag of this pattern, or `None` if it is a wildcard. */
+  def tagOf(pattern: Pattern): Option[Tag]
+
+  def compile(query: Query[Tag, Path]): MFT[NonEmptyList[Guard], Tag, Tag] = dsl { implicit builder =>
+    val q0 = state(args = 0, initial = true)
+    val qinit = state(args = 1)
+    val qcopy = state(args = 0)
+
+    qcopy(anyNode) -> copy(qcopy(x1)) ~ qcopy(x2)
+    qcopy(anyLeaf) -> copy
+    qcopy(epsilon) -> eps
+
+    // input is copied in the first argument
+    q0(any) -> qinit(x0, qcopy(x0))
+
+    def translatePath(path: Path, start: builder.StateBuilder, end: builder.StateBuilder): Unit = {
+      val dfa = path2regular(path).deriveDFA
+      // resolve transitions into patterns and guards
+      val resolvedTransitions =
+        dfa.transitions.toList.zipWithIndex.flatMap { case (transitions, src) =>
+          transitions.flatMap { case (cond, tgt) =>
+            cases(cond).map { case (pat, guard) =>
+              (src, pat, NonEmptyList.fromList(guard), tgt)
+            }
+          }
+        }
+      val outgoingTransitions = resolvedTransitions.groupMapReduce(_._1)(t => Set(t._4))(_ ++ _)
+      val incomingTransitions = resolvedTransitions.groupMapReduce(_._4)(t => Set(t._1))(_ ++ _)
+      @tailrec
+      def dropUnreachableStates(qs: List[Int], visited: Set[Int], reach: Map[Int, Set[Int]]): Set[Int] =
+        qs match {
+          case Nil => visited
+          case q :: qs =>
+            if (visited.contains(q))
+              dropUnreachableStates(qs, visited, reach)
+            else
+              dropUnreachableStates(qs ++ reach.getOrElse(q, Set.empty).diff(visited), visited + q, reach)
+        }
+      // keep only the states that are part of realisable paths
+      val reachableStates = dropUnreachableStates(List(dfa.init), Set.empty, outgoingTransitions)
+      val aliveStates = dropUnreachableStates(dfa.finals.toList, Set.empty, incomingTransitions)
+      // we now have the final transitions
+      val finalTransitions = resolvedTransitions
+        .filter { case (src, _, _, tgt) =>
+          reachableStates.contains(src) && aliveStates.contains(tgt)
+        }
+        .groupMap(_._1)(t => (t._2, t._3, t._4))
+      // we can apply the DFA to MFT translation now
+      finalTransitions.foldLeft(Map.empty[Int, builder.StateBuilder]) { case (states, (src, transitions)) =>
+        val initialSrc = src === dfa.init
+        val (q1, states1) =
+          states.get(src) match {
+            case Some(q1) => (q1, states)
+            case None =>
+              val q1 =
+                if (initialSrc)
+                  start
+                else
+                  state(args = start.nargs)
+              (q1, states.updated(src, q1))
+          }
+        val copyArgs = List.tabulate(q1.nargs)(y(_))
+        transitions.foldLeft(states1) { case (states, (pattern, guard, tgt)) =>
+          val finalTgt = dfa.finals.contains(tgt)
+          val (q2, states1) =
+            states.get(tgt) match {
+              case Some(q2) => (q2, states)
+              case None =>
+                val q2 =
+                  if (finalTgt)
+                    end
+                  else
+                    state(args = start.nargs)
+                (q2, states.updated(tgt, q2))
+            }
+          val pat: builder.Guardable = tagOf(pattern).fold(anyNode)(aNode(_))
+          if (!initialSrc && !finalTgt) {
+            q1(pat.when(guard)) -> q2(x1, copyArgs: _*) ~ q1(x2, copyArgs: _*)
+          } else if (initialSrc && !finalTgt) {
+            q1(pat.when(guard)) -> q2(x1, copyArgs: _*)
+          } else if (!initialSrc && finalTgt) {
+            q1(pat.when(guard)) -> q2(x0, (copyArgs :+ copy(qcopy(x1))): _*)
+          } else {
+            q1(pat.when(guard)) -> q2(x1, (copyArgs :+ copy(qcopy(x1))): _*)
+          }
+          states1
+        }
+      }: Unit
+    }
+
+    def translate(query: Query[Tag, Path], vars: List[String], q: builder.StateBuilder): Unit =
+      query match {
+        case Query.ForClause(variable, source, result) =>
+          val q1 = state(args = q.nargs + 1)
+
+          // compile the variable binding path
+          translatePath(source, q, q1)
+
+          // then the body with the bound variable
+          translate(result, variable :: vars, q1)
+
+        case Query.LetClause(variable, query, result) =>
+          val qv = state(args = q.nargs)
+          val q1 = state(args = q.nargs + 1)
+
+          // compile the variable binding query
+          translate(query, vars, qv)
+          // then the body with the bound variable
+          translate(result, variable :: vars, q1)
+
+          // bind everything
+          val copyArgs = List.tabulate(q.nargs)(y(_))
+          q(any) -> q1(x0, (copyArgs :+ qv(x0, copyArgs: _*)): _*)
+
+        case Query.Ordpath(path) =>
+          val q1 = state(args = q.nargs + 1)
+
+          // compile the path
+          translatePath(path, q, q1)
+
+          // emit the result
+          q1(any) -> y(q.nargs)
+        case Query.Element(tag, Some(child)) =>
+          val q1 = state(args = q.nargs)
+
+          // translate the child query
+          translate(child, vars, q1)
+
+          // bind it
+          val copyArgs = List.tabulate(q.nargs)(y(_))
+          q(any) -> node(tag)(q1(x0, copyArgs: _*))
+
+        case Query.Element(tag, None) =>
+          // just emit it
+          q(any) -> leaf(tag)
+
+        case Query.Variable(name) =>
+          // variable named are pushed on top of the list, so indexing is reversed
+          q(any) -> y(vars.size - 1 - vars.indexOf(name))
+
+        case Query.Sequence(queries) =>
+          val copyArgs = List.tabulate(q.nargs)(y(_))
+
+          // compile and sequence every query in the sequence
+          val rhs =
+            queries.foldLeft[Rhs[Tag]](eps) { (acc, query) =>
+              val q1 = state(args = q.nargs)
+
+              // translate the query
+              translate(query, vars, q1)
+
+              acc ~ q1(x0, copyArgs: _*)
+            }
+
+          // emit rhs for any input
+          q(any) -> rhs
+      }
+
+    translate(query, List("$input"), qinit)
+  }
+
+}

--- a/finite-state/shared/src/main/scala/fs2/data/mft/query/QueryCompiler.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/query/QueryCompiler.scala
@@ -194,6 +194,9 @@ private[fs2] abstract class QueryCompiler[Tag, Path] {
 
             // emit rhs for any input
             q(any) -> rhs
+
+          case Query.LeafFunction(f) =>
+            q(anyLeaf) -> applyToLeaf(f)
         }
 
       translate(query, List("$input"), qinit)

--- a/finite-state/shared/src/main/scala/fs2/data/pattern/Compiler.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/pattern/Compiler.scala
@@ -206,12 +206,12 @@ class Compiler[F[_], Expr, Tag, Pat, Out](implicit
             if (nonTrivialIdx >= 0) {
               // there are non trivially true guards after the first one
               specialize(col, Pat.trueTag, Nil, matrix.take(1 + nonTrivialIdx)).map { smat =>
-                (g, Map(Pat.trueTag -> ((false, Nil, smat))), (false, matrix.drop(1 + nonTrivialIdx)).some)
+                (g, Map(Pat.trueTag -> ((false, Nil, smat))), (true, matrix.drop(1 + nonTrivialIdx)).some)
               }
             } else {
               // only trivially false guard afterwards
               specialize(col, Pat.trueTag, Nil, matrix).map { smat =>
-                (g, Map(Pat.trueTag -> ((false, Nil, smat))), (false, defaultMatrix(col, matrix)).some)
+                (g, Map(Pat.trueTag -> ((false, Nil, smat))), (true, defaultMatrix(col, matrix)).some)
               }
             }
         }

--- a/finite-state/shared/src/main/scala/fs2/data/pattern/Selectable.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/pattern/Selectable.scala
@@ -16,6 +16,8 @@
 
 package fs2.data.pattern
 
+import cats.Show
+
 /** Describes the structure of an expression in term of constructor
   * trees that can be selected.
   */
@@ -42,6 +44,9 @@ object Evaluator {
   * To be used when a pattern language has no guards.
   */
 sealed trait NoGuard
+object NoGuard {
+  implicit val show: Show[NoGuard] = Show.show(_ => "")
+}
 
 object Selectable {
   def apply[Expr, Tag](implicit ev: Selectable[Expr, Tag]): Selectable[Expr, Tag] =

--- a/finite-state/shared/src/test/scala/fs2/data/MiniXML.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/MiniXML.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package fs2.data.pattern
-
-import fs2.data.esp.Tag
-import fs2.data.esp.Conversion
+package fs2.data
 
 import cats.Eq
+import fs2.data.esp.{Conversion, Tag}
+import fs2.data.pattern.{ConstructorTree, Selectable}
 
 sealed trait MiniXML
 object MiniXML {

--- a/finite-state/shared/src/test/scala/fs2/data/MiniXML.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/MiniXML.scala
@@ -59,9 +59,9 @@ object MiniXML {
   implicit object MiniXMLShow extends Show[MiniXML] {
     def show(node: MiniXML): String =
       node match {
-        case Open(name) => s"<$name>"
+        case Open(name)  => s"<$name>"
         case Close(name) => s"</$name>"
-        case Text(t) => t
+        case Text(t)     => t
       }
   }
 

--- a/finite-state/shared/src/test/scala/fs2/data/MiniXML.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/MiniXML.scala
@@ -19,6 +19,7 @@ package fs2.data
 import cats.Eq
 import fs2.data.esp.{Conversion, Tag}
 import fs2.data.pattern.{ConstructorTree, Selectable}
+import cats.Show
 
 sealed trait MiniXML
 object MiniXML {
@@ -53,6 +54,15 @@ object MiniXML {
 
     override def makeLeaf(t: String): MiniXML = MiniXML.Text(t)
 
+  }
+
+  implicit object MiniXMLShow extends Show[MiniXML] {
+    def show(node: MiniXML): String =
+      node match {
+        case Open(name) => s"<$name>"
+        case Close(name) => s"</$name>"
+        case Text(t) => t
+      }
   }
 
 }

--- a/finite-state/shared/src/test/scala/fs2/data/MiniXPath.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/MiniXPath.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fs2.data
 
 import cats.data.NonEmptyList

--- a/finite-state/shared/src/test/scala/fs2/data/MiniXPath.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/MiniXPath.scala
@@ -22,6 +22,6 @@ case class MiniXPath(steps: NonEmptyList[Step])
 
 sealed trait Step
 object Step {
-  case class Child(name: String) extends Step
-  case class Descendant(name: String) extends Step
+  case class Child(name: Option[String]) extends Step
+  case class Descendant(name: Option[String]) extends Step
 }

--- a/finite-state/shared/src/test/scala/fs2/data/MiniXPath.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/MiniXPath.scala
@@ -1,0 +1,11 @@
+package fs2.data
+
+import cats.data.NonEmptyList
+
+case class MiniXPath(steps: NonEmptyList[Step])
+
+sealed trait Step
+object Step {
+  case class Child(name: String) extends Step
+  case class Descendant(name: String) extends Step
+}

--- a/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
@@ -110,13 +110,14 @@ object QuerySpec extends SimpleIOSuite {
   }
 
   test("child path") {
-    MiniXQueryCompiler
-      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(Some("a"))))))
-      .esp[IO]
-      .flatMap { esp =>
-        Stream
-          .emits(
-            List[MiniXML](
+    ignore("debug") >>
+      MiniXQueryCompiler
+        .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(Some("a"))))))
+        .esp[IO]
+        .flatMap { esp =>
+          Stream
+            .emits(
+              List[MiniXML](
               // format: off
               MiniXML.Open("a"),
                 MiniXML.Open("a"),
@@ -129,14 +130,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("b"),
               MiniXML.Close("a"),
               // format: on
+              )
             )
-          )
-          .through(esp.pipe)
-          .compile
-          .toList
-          .map { events =>
-            expect.eql(
-              List(
+            .through(esp.pipe[MiniXML, MiniXML])
+            .compile
+            .toList
+            .map { events =>
+              expect.eql(
+                List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -149,21 +150,22 @@ object QuerySpec extends SimpleIOSuite {
                   MiniXML.Close("b"),
                 MiniXML.Close("a"),
                 // format: on
-              ),
-              events
-            )
-          }
-      }
+                ),
+                events
+              )
+            }
+        }
   }
 
   test("any child path") {
-    MiniXQueryCompiler
-      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(None)))))
-      .esp[IO]
-      .flatMap { esp =>
-        Stream
-          .emits(
-            List[MiniXML](
+    ignore("debug") >>
+      MiniXQueryCompiler
+        .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(None)))))
+        .esp[IO]
+        .flatMap { esp =>
+          Stream
+            .emits(
+              List[MiniXML](
               // format: off
               MiniXML.Open("a"),
                 MiniXML.Open("a"),
@@ -176,14 +178,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("c"),
               MiniXML.Close("a"),
               // format: on
+              )
             )
-          )
-          .through(esp.pipe)
-          .compile
-          .toList
-          .map { events =>
-            expect.eql(
-              List(
+            .through(esp.pipe[MiniXML, MiniXML])
+            .compile
+            .toList
+            .map { events =>
+              expect.eql(
+                List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -196,21 +198,22 @@ object QuerySpec extends SimpleIOSuite {
                   MiniXML.Close("c"),
                 MiniXML.Close("a"),
                 // format: on
-              ),
-              events
-            )
-          }
-      }
+                ),
+                events
+              )
+            }
+        }
   }
 
   test("descendant path") {
-    MiniXQueryCompiler
-      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a"))))))
-      .esp[IO]
-      .flatMap { esp =>
-        Stream
-          .emits(
-            List[MiniXML](
+    ignore("debug") >>
+      MiniXQueryCompiler
+        .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a"))))))
+        .esp[IO]
+        .flatMap { esp =>
+          Stream
+            .emits(
+              List[MiniXML](
               // format: off
               MiniXML.Open("doc"),
                 MiniXML.Open("a"),
@@ -225,14 +228,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("a"),
               MiniXML.Close("doc"),
               // format: on
+              )
             )
-          )
-          .through(esp.pipe)
-          .compile
-          .toList
-          .map { events =>
-            expect.eql(
-              List(
+            .through(esp.pipe[MiniXML, MiniXML])
+            .compile
+            .toList
+            .map { events =>
+              expect.eql(
+                List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -253,21 +256,22 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Open("a"),
                 MiniXML.Close("a"),
                 // format: on
-              ),
-              events
-            )
-          }
-      }
+                ),
+                events
+              )
+            }
+        }
   }
 
   test("any descendant path") {
-    MiniXQueryCompiler
-      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(None)))))
-      .esp[IO]
-      .flatMap { esp =>
-        Stream
-          .emits(
-            List[MiniXML](
+    ignore("debug") >>
+      MiniXQueryCompiler
+        .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(None)))))
+        .esp[IO]
+        .flatMap { esp =>
+          Stream
+            .emits(
+              List[MiniXML](
               // format: off
               MiniXML.Open("a"),
                 MiniXML.Open("a"),
@@ -280,14 +284,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("b"),
               MiniXML.Close("a"),
               // format: on
+              )
             )
-          )
-          .through(esp.pipe)
-          .compile
-          .toList
-          .map { events =>
-            expect.eql(
-              List(
+            .through(esp.pipe[MiniXML, MiniXML])
+            .compile
+            .toList
+            .map { events =>
+              expect.eql(
+                List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -312,23 +316,23 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Open("a"),
                 MiniXML.Close("a"),
                 // format: on
-              ),
-              events
-            )
-          }
-      }
+                ),
+                events
+              )
+            }
+        }
   }
 
   test("simple let") {
-    MiniXQueryCompiler
-      .compile(
-        Query
+    ignore("debug") >>
+      MiniXQueryCompiler
+        .compile(Query
           .LetClause("v", Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a"))))), Query.Variable("v")))
-      .esp[IO]
-      .flatMap { esp =>
-        Stream
-          .emits(
-            List[MiniXML](
+        .esp[IO]
+        .flatMap { esp =>
+          Stream
+            .emits(
+              List[MiniXML](
               // format: off
               MiniXML.Open("doc"),
                 MiniXML.Open("a"),
@@ -343,14 +347,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("a"),
               MiniXML.Close("doc"),
               // format: on
+              )
             )
-          )
-          .through(esp.pipe)
-          .compile
-          .toList
-          .map { events =>
-            expect.eql(
-              List(
+            .through(esp.pipe[MiniXML, MiniXML])
+            .compile
+            .toList
+            .map { events =>
+              expect.eql(
+                List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -371,23 +375,25 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Open("a"),
                 MiniXML.Close("a"),
                 // format: on
-              ),
-              events
-            )
-          }
-      }
+                ),
+                events
+              )
+            }
+        }
   }
 
   test("simple for") {
-    MiniXQueryCompiler
-      .compile(
-        Query
-          .ForClause("v", MiniXPath(NonEmptyList.one(Step.Descendant(Some("a")))), Query.Variable("v")))
-      .esp[IO]
-      .flatMap { esp =>
-        Stream
-          .emits(
-            List[MiniXML](
+    ignore("debug") >>
+      IO(
+        MiniXQueryCompiler
+          .compile(Query
+            .ForClause("v", MiniXPath(NonEmptyList.one(Step.Descendant(Some("a")))), Query.Variable("v"))))
+        .flatTap(IO.println(_))
+        .flatMap(_.esp[IO])
+        .flatMap { esp =>
+          Stream
+            .emits(
+              List[MiniXML](
               // format: off
               MiniXML.Open("doc"),
                 MiniXML.Open("a"),
@@ -402,14 +408,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("a"),
               MiniXML.Close("doc"),
               // format: on
+              )
             )
-          )
-          .through(esp.pipe)
-          .compile
-          .toList
-          .map { events =>
-            expect.eql(
-              List(
+            .through(esp.pipe[MiniXML, MiniXML])
+            .compile
+            .toList
+            .map { events =>
+              expect.eql(
+                List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -430,11 +436,11 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Open("a"),
                 MiniXML.Close("a"),
                 // format: on
-              ),
-              events
-            )
-          }
-      }
+                ),
+                events
+              )
+            }
+        }
   }
 
   test("nested for") {
@@ -442,12 +448,12 @@ object QuerySpec extends SimpleIOSuite {
       MiniXQueryCompiler
         .compile(Query.ForClause(
           "a",
-          MiniXPath(NonEmptyList.one(Step.Descendant(Some("a")))),
+          MiniXPath(NonEmptyList.one(Step.Child(Some("a")))),
           Query.ForClause("b",
                           MiniXPath(NonEmptyList.one(Step.Child(Some("b")))),
                           Query.Sequence(NonEmptyList.of(Query.Variable("a"), Query.Variable("b"))))
         )))
-    .flatTap(IO.println(_))
+      .flatTap(IO.println(_))
       .flatMap(_.esp[IO])
       .flatMap { esp =>
         Stream
@@ -457,18 +463,12 @@ object QuerySpec extends SimpleIOSuite {
               MiniXML.Open("a"),
                 MiniXML.Open("b"),
                 MiniXML.Close("b"),
-                MiniXML.Open("a"),
-                  MiniXML.Open("b"),
-                  MiniXML.Close("b"),
-                MiniXML.Close("a"),
-                MiniXML.Open("b"),
-                  MiniXML.Open("c"),
-                  MiniXML.Close("c"),
-                MiniXML.Close("b"),
+                MiniXML.Open("c"),
+                MiniXML.Close("c"),
               MiniXML.Close("a"),
               // format: on
             ))
-          .through(esp.pipe)
+          .through(esp.pipe[MiniXML, MiniXML])
           .compile
           .toList
           .map { events =>
@@ -478,36 +478,8 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Open("a"),
                   MiniXML.Open("b"),
                   MiniXML.Close("b"),
-                  MiniXML.Open("a"),
-                    MiniXML.Open("b"),
-                    MiniXML.Close("b"),
-                  MiniXML.Close("a"),
-                  MiniXML.Open("b"),
-                    MiniXML.Open("c"),
-                    MiniXML.Close("c"),
-                  MiniXML.Close("b"),
-                MiniXML.Close("a"),
-                MiniXML.Open("b"),
-                MiniXML.Close("b"),
-                MiniXML.Open("a"),
-                  MiniXML.Open("b"),
-                  MiniXML.Close("b"),
-                  MiniXML.Open("a"),
-                    MiniXML.Open("b"),
-                    MiniXML.Close("b"),
-                  MiniXML.Close("a"),
-                  MiniXML.Open("b"),
-                    MiniXML.Open("c"),
-                    MiniXML.Close("c"),
-                  MiniXML.Close("b"),
-                MiniXML.Close("a"),
-                MiniXML.Open("b"),
                   MiniXML.Open("c"),
                   MiniXML.Close("c"),
-                MiniXML.Close("b"),
-                MiniXML.Open("a"),
-                  MiniXML.Open("b"),
-                  MiniXML.Close("b"),
                 MiniXML.Close("a"),
                 MiniXML.Open("b"),
                 MiniXML.Close("b"),

--- a/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
@@ -1,0 +1,149 @@
+package fs2
+package data
+package mft
+package query
+
+import cats.Eq
+import cats.effect.{IO, Resource}
+import fs2.data.esp.{Conversion, ESP, Tag}
+import fs2.data.pattern.{ConstructorTree, Evaluator}
+import weaver._
+
+import pfsa.{Candidate, Pred, Regular}
+import cats.data.NonEmptyList
+
+object QuerySpec extends IOSuite {
+
+  type Res = ESP[IO, NonEmptyList[Set[String]], String, String]
+
+  implicit object StringConversions extends Conversion[String, MiniXML] {
+
+    override def makeOpen(t: String): MiniXML = MiniXML.Open(t)
+
+    override def makeClose(t: String): MiniXML = MiniXML.Close(t)
+
+    override def makeLeaf(t: String): MiniXML = MiniXML.Text(t)
+
+  }
+
+  implicit object evaluator extends Evaluator[NonEmptyList[Set[String]], Tag[String]] {
+
+    override def eval(guard: NonEmptyList[Set[String]], tree: ConstructorTree[Tag[String]]): Option[Tag[String]] =
+      tree match {
+        case ConstructorTree(Tag.Open, List(ConstructorTree(Tag.Name(n), _))) if guard.forall(_.contains(n)) =>
+          Some(Tag.True)
+        case ConstructorTree(Tag.Name(n), _) if guard.forall(_.contains(n)) => Some(Tag.True)
+        case _                                                              => None
+      }
+
+  }
+
+  object MiniXQueryCompiler extends QueryCompiler[String, MiniXPath] {
+
+    type Matcher = Set[String]
+    type Char = String
+    type Pattern = Option[String]
+    type Guard = Set[String]
+
+    override implicit object predicate extends Pred[Matcher, Char] {
+
+      override def satsifies(p: Matcher)(e: Char): Boolean = p.contains(e)
+
+      override val always: Matcher = Set("a", "b", "c", "d", "doc")
+
+      override val never: Matcher = Set()
+
+      override def and(p1: Matcher, p2: Matcher): Matcher = p1.intersect(p2)
+
+      override def or(p1: Matcher, p2: Matcher): Matcher = p1.union(p2)
+
+      override def not(p: Matcher): Matcher = always.diff(p)
+
+      override def isSatisfiable(p: Matcher): Boolean = p.nonEmpty
+
+    }
+
+    override implicit object candidate extends Candidate[Matcher, Char] {
+
+      override def pick(set: Matcher): Option[Char] = set.headOption
+
+    }
+
+    override implicit def charsEq: Eq[Matcher] = Eq.fromUniversalEquals
+
+    override def path2regular(path: MiniXPath): Regular[Matcher] =
+      path.steps.foldLeft(Regular.epsilon[Matcher]) {
+        case (acc, Step.Child(name)) =>
+          acc ~ Regular.chars(Set(name))
+        case (acc, Step.Descendant(name)) =>
+          acc ~ Regular.any.rep ~ Regular.chars(Set(name))
+      }
+
+    override def cases(matcher: Matcher): List[(Pattern, List[Guard])] =
+      if (matcher.isEmpty)
+        Nil
+      else if (matcher.size == 1)
+        List(matcher.headOption -> Nil)
+      else
+        List(None -> List(matcher))
+
+    override def tagOf(pattern: Pattern): Option[String] = pattern
+
+  }
+
+  override def sharedResource: Resource[IO, Res] = Resource.eval {
+    val mft =
+      MiniXQueryCompiler.compile(
+        Query.ForClause(
+          "v1",
+          MiniXPath(NonEmptyList.one(Step.Descendant("a"))),
+          Query.ForClause(
+            "v2",
+            MiniXPath(NonEmptyList.one(Step.Descendant("b"))),
+            Query.LetClause(
+              "v3",
+              Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant("c")))),
+              Query.LetClause(
+                "v4",
+                Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant("d")))),
+                Query.Sequence(NonEmptyList
+                  .of(Query.Variable("v1"), Query.Variable("v2"), Query.Variable("v3"), Query.Variable("v4")))
+              )
+            )
+          )
+        ))
+    mft.esp[IO]
+  }
+
+  test("simple query") { esp =>
+    Stream
+      .emits(
+        List[MiniXML](
+          // format: off
+          MiniXML.Open("doc"),
+            MiniXML.Open("a"),
+              MiniXML.Open("b"),
+                MiniXML.Open("c"),
+                MiniXML.Close("c"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
+              MiniXML.Close("b"),
+              MiniXML.Open("b"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
+              MiniXML.Close("b"),
+            MiniXML.Close("a"),
+          MiniXML.Close("doc"),
+          // format: on
+        )
+      )
+      .covary[IO]
+      .debug(s => s"before: $s")
+      .through(esp.pipe)
+      .debug(s => s"after: $s")
+      .compile
+      .drain
+      .as(expect(true))
+  }
+
+}

--- a/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fs2
 package data
 package mft
@@ -124,7 +140,11 @@ object QuerySpec extends IOSuite {
             MiniXML.Open("a"),
               MiniXML.Open("b"),
                 MiniXML.Open("c"),
+                  MiniXML.Open("c"),
+                  MiniXML.Close("c"),
                 MiniXML.Close("c"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
                 MiniXML.Open("d"),
                 MiniXML.Close("d"),
               MiniXML.Close("b"),
@@ -138,12 +158,69 @@ object QuerySpec extends IOSuite {
         )
       )
       .covary[IO]
-      .debug(s => s"before: $s")
       .through(esp.pipe)
-      .debug(s => s"after: $s")
       .compile
-      .drain
-      .as(expect(true))
+      .toList
+      .map(events =>
+        expect.same(
+          List[MiniXML](
+            // format: off
+            MiniXML.Open("a"),
+              MiniXML.Open("b"),
+                MiniXML.Open("c"),
+                  MiniXML.Open("c"),
+                  MiniXML.Close("c"),
+                MiniXML.Close("c"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
+              MiniXML.Close("b"),
+              MiniXML.Open("b"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
+              MiniXML.Close("b"),
+            MiniXML.Close("a"),
+            MiniXML.Open("b"),
+              MiniXML.Open("c"),
+                MiniXML.Open("c"),
+                MiniXML.Close("c"),
+              MiniXML.Close("c"),
+              MiniXML.Open("d"),
+              MiniXML.Close("d"),
+              MiniXML.Open("d"),
+              MiniXML.Close("d"),
+            MiniXML.Close("b"),
+            MiniXML.Open("c"),
+              MiniXML.Open("c"),
+              MiniXML.Close("c"),
+            MiniXML.Close("c"),
+            MiniXML.Open("c"),
+            MiniXML.Close("c"),
+            MiniXML.Open("d"),
+            MiniXML.Close("d"),
+            MiniXML.Open("a"),
+              MiniXML.Open("b"),
+                MiniXML.Open("c"),
+                MiniXML.Close("c"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
+              MiniXML.Close("b"),
+              MiniXML.Open("b"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
+              MiniXML.Close("b"),
+            MiniXML.Close("a"),
+            MiniXML.Open("b"),
+              MiniXML.Open("d"),
+              MiniXML.Close("d"),
+            MiniXML.Close("b"),
+            MiniXML.Open("d"),
+            MiniXML.Close("d"),
+            // format: on
+          ),
+          events
+        ))
   }
 
 }

--- a/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
@@ -110,14 +110,14 @@ object QuerySpec extends SimpleIOSuite {
   }
 
   test("child path") {
-    ignore("debug") >>
-      MiniXQueryCompiler
-        .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(Some("a"))))))
-        .esp[IO]
-        .flatMap { esp =>
-          Stream
-            .emits(
-              List[MiniXML](
+    ignore("debugging")
+    MiniXQueryCompiler
+      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(Some("a"))))))
+      .esp[IO]
+      .flatMap { esp =>
+        Stream
+          .emits(
+            List[MiniXML](
               // format: off
               MiniXML.Open("a"),
                 MiniXML.Open("a"),
@@ -130,14 +130,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("b"),
               MiniXML.Close("a"),
               // format: on
-              )
             )
-            .through(esp.pipe[MiniXML, MiniXML])
-            .compile
-            .toList
-            .map { events =>
-              expect.eql(
-                List(
+          )
+          .through(esp.pipe[MiniXML, MiniXML])
+          .compile
+          .toList
+          .map { events =>
+            expect.eql(
+              List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -150,22 +150,21 @@ object QuerySpec extends SimpleIOSuite {
                   MiniXML.Close("b"),
                 MiniXML.Close("a"),
                 // format: on
-                ),
-                events
-              )
-            }
-        }
+              ),
+              events
+            )
+          }
+      }
   }
 
   test("any child path") {
-    ignore("debug") >>
-      MiniXQueryCompiler
-        .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(None)))))
-        .esp[IO]
-        .flatMap { esp =>
-          Stream
-            .emits(
-              List[MiniXML](
+    MiniXQueryCompiler
+      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(None)))))
+      .esp[IO]
+      .flatMap { esp =>
+        Stream
+          .emits(
+            List[MiniXML](
               // format: off
               MiniXML.Open("a"),
                 MiniXML.Open("a"),
@@ -178,14 +177,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("c"),
               MiniXML.Close("a"),
               // format: on
-              )
             )
-            .through(esp.pipe[MiniXML, MiniXML])
-            .compile
-            .toList
-            .map { events =>
-              expect.eql(
-                List(
+          )
+          .through(esp.pipe[MiniXML, MiniXML])
+          .compile
+          .toList
+          .map { events =>
+            expect.eql(
+              List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -198,22 +197,21 @@ object QuerySpec extends SimpleIOSuite {
                   MiniXML.Close("c"),
                 MiniXML.Close("a"),
                 // format: on
-                ),
-                events
-              )
-            }
-        }
+              ),
+              events
+            )
+          }
+      }
   }
 
   test("descendant path") {
-    ignore("debug") >>
-      MiniXQueryCompiler
-        .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a"))))))
-        .esp[IO]
-        .flatMap { esp =>
-          Stream
-            .emits(
-              List[MiniXML](
+    MiniXQueryCompiler
+      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a"))))))
+      .esp[IO]
+      .flatMap { esp =>
+        Stream
+          .emits(
+            List[MiniXML](
               // format: off
               MiniXML.Open("doc"),
                 MiniXML.Open("a"),
@@ -228,14 +226,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("a"),
               MiniXML.Close("doc"),
               // format: on
-              )
             )
-            .through(esp.pipe[MiniXML, MiniXML])
-            .compile
-            .toList
-            .map { events =>
-              expect.eql(
-                List(
+          )
+          .through(esp.pipe[MiniXML, MiniXML])
+          .compile
+          .toList
+          .map { events =>
+            expect.eql(
+              List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -256,22 +254,21 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Open("a"),
                 MiniXML.Close("a"),
                 // format: on
-                ),
-                events
-              )
-            }
-        }
+              ),
+              events
+            )
+          }
+      }
   }
 
   test("any descendant path") {
-    ignore("debug") >>
-      MiniXQueryCompiler
-        .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(None)))))
-        .esp[IO]
-        .flatMap { esp =>
-          Stream
-            .emits(
-              List[MiniXML](
+    MiniXQueryCompiler
+      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(None)))))
+      .esp[IO]
+      .flatMap { esp =>
+        Stream
+          .emits(
+            List[MiniXML](
               // format: off
               MiniXML.Open("a"),
                 MiniXML.Open("a"),
@@ -284,14 +281,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("b"),
               MiniXML.Close("a"),
               // format: on
-              )
             )
-            .through(esp.pipe[MiniXML, MiniXML])
-            .compile
-            .toList
-            .map { events =>
-              expect.eql(
-                List(
+          )
+          .through(esp.pipe[MiniXML, MiniXML])
+          .compile
+          .toList
+          .map { events =>
+            expect.eql(
+              List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -316,23 +313,23 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Open("a"),
                 MiniXML.Close("a"),
                 // format: on
-                ),
-                events
-              )
-            }
-        }
+              ),
+              events
+            )
+          }
+      }
   }
 
   test("simple let") {
-    ignore("debug") >>
-      MiniXQueryCompiler
-        .compile(Query
+    MiniXQueryCompiler
+      .compile(
+        Query
           .LetClause("v", Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a"))))), Query.Variable("v")))
-        .esp[IO]
-        .flatMap { esp =>
-          Stream
-            .emits(
-              List[MiniXML](
+      .esp[IO]
+      .flatMap { esp =>
+        Stream
+          .emits(
+            List[MiniXML](
               // format: off
               MiniXML.Open("doc"),
                 MiniXML.Open("a"),
@@ -347,14 +344,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("a"),
               MiniXML.Close("doc"),
               // format: on
-              )
             )
-            .through(esp.pipe[MiniXML, MiniXML])
-            .compile
-            .toList
-            .map { events =>
-              expect.eql(
-                List(
+          )
+          .through(esp.pipe[MiniXML, MiniXML])
+          .compile
+          .toList
+          .map { events =>
+            expect.eql(
+              List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -375,25 +372,23 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Open("a"),
                 MiniXML.Close("a"),
                 // format: on
-                ),
-                events
-              )
-            }
-        }
+              ),
+              events
+            )
+          }
+      }
   }
 
   test("simple for") {
-    ignore("debug") >>
-      IO(
-        MiniXQueryCompiler
-          .compile(Query
-            .ForClause("v", MiniXPath(NonEmptyList.one(Step.Descendant(Some("a")))), Query.Variable("v"))))
-        .flatTap(IO.println(_))
-        .flatMap(_.esp[IO])
-        .flatMap { esp =>
-          Stream
-            .emits(
-              List[MiniXML](
+    IO(
+      MiniXQueryCompiler
+        .compile(Query
+          .ForClause("v", MiniXPath(NonEmptyList.one(Step.Descendant(Some("a")))), Query.Variable("v"))))
+      .flatMap(_.esp[IO])
+      .flatMap { esp =>
+        Stream
+          .emits(
+            List[MiniXML](
               // format: off
               MiniXML.Open("doc"),
                 MiniXML.Open("a"),
@@ -408,14 +403,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("a"),
               MiniXML.Close("doc"),
               // format: on
-              )
             )
-            .through(esp.pipe[MiniXML, MiniXML])
-            .compile
-            .toList
-            .map { events =>
-              expect.eql(
-                List(
+          )
+          .through(esp.pipe[MiniXML, MiniXML])
+          .compile
+          .toList
+          .map { events =>
+            expect.eql(
+              List(
                 // format: off
                 MiniXML.Open("a"),
                   MiniXML.Open("a"),
@@ -436,11 +431,11 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Open("a"),
                 MiniXML.Close("a"),
                 // format: on
-                ),
-                events
-              )
-            }
-        }
+              ),
+              events
+            )
+          }
+      }
   }
 
   test("nested for") {
@@ -448,24 +443,25 @@ object QuerySpec extends SimpleIOSuite {
       MiniXQueryCompiler
         .compile(Query.ForClause(
           "a",
-          MiniXPath(NonEmptyList.one(Step.Child(Some("a")))),
+          MiniXPath(NonEmptyList.one(Step.Descendant(Some("a")))),
           Query.ForClause("b",
-                          MiniXPath(NonEmptyList.one(Step.Child(Some("b")))),
+                          MiniXPath(NonEmptyList.one(Step.Child(None))),
                           Query.Sequence(NonEmptyList.of(Query.Variable("a"), Query.Variable("b"))))
         )))
-      .flatTap(IO.println(_))
       .flatMap(_.esp[IO])
       .flatMap { esp =>
         Stream
           .emits(
             List[MiniXML](
               // format: off
-              MiniXML.Open("a"),
-                MiniXML.Open("b"),
-                MiniXML.Close("b"),
-                MiniXML.Open("c"),
-                MiniXML.Close("c"),
-              MiniXML.Close("a"),
+              MiniXML.Open("doc"),
+                MiniXML.Open("a"),
+                  MiniXML.Open("b"),
+                  MiniXML.Close("b"),
+                  MiniXML.Open("c"),
+                  MiniXML.Close("c"),
+                MiniXML.Close("a"),
+              MiniXML.Close("doc"),
               // format: on
             ))
           .through(esp.pipe[MiniXML, MiniXML])
@@ -483,6 +479,14 @@ object QuerySpec extends SimpleIOSuite {
                 MiniXML.Close("a"),
                 MiniXML.Open("b"),
                 MiniXML.Close("b"),
+                MiniXML.Open("a"),
+                  MiniXML.Open("b"),
+                  MiniXML.Close("b"),
+                  MiniXML.Open("c"),
+                  MiniXML.Close("c"),
+                MiniXML.Close("a"),
+                MiniXML.Open("c"),
+                MiniXML.Close("c"),
                 // format: on
               ),
               events
@@ -491,119 +495,124 @@ object QuerySpec extends SimpleIOSuite {
       }
   }
 
-  test("simple query") {
-    ignore("debugging")
-    // MiniXQueryCompiler
-    //  .compile(
-    //    Query.ForClause(
-    //      "v1",
-    //      MiniXPath(NonEmptyList.one(Step.Descendant("a"))),
-    //      Query.ForClause(
-    //        "v2",
-    //        MiniXPath(NonEmptyList.one(Step.Descendant("b"))),
-    //        Query.LetClause(
-    //          "v3",
-    //          Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant("c")))),
-    //          Query.LetClause(
-    //            "v4",
-    //            Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant("d")))),
-    //            Query.Sequence(NonEmptyList
-    //              .of(Query.Variable("v1"), Query.Variable("v2"), Query.Variable("v3"), Query.Variable("v4")))
-    //          )
-    //        )
-    //      )
-    //    ))
-    //  .esp[IO]
-    //  .flatMap { esp =>
-    //    Stream
-    //      .emits(
-    //        List[MiniXML](
-    //          // format: off
-    //          MiniXML.Open("doc"),
-    //            MiniXML.Open("a"),
-    //              MiniXML.Open("b"),
-    //                MiniXML.Open("c"),
-    //                  MiniXML.Open("c"),
-    //                  MiniXML.Close("c"),
-    //                MiniXML.Close("c"),
-    //                MiniXML.Open("d"),
-    //                MiniXML.Close("d"),
-    //                MiniXML.Open("d"),
-    //                MiniXML.Close("d"),
-    //              MiniXML.Close("b"),
-    //              MiniXML.Open("b"),
-    //                MiniXML.Open("d"),
-    //                MiniXML.Close("d"),
-    //              MiniXML.Close("b"),
-    //            MiniXML.Close("a"),
-    //          MiniXML.Close("doc"),
-    //          // format: on
-    //        )
-    //      )
-    //      .through(esp.pipe)
-    //      .compile
-    //      .toList
-    //      .map(events =>
-    //        expect.same(
-    //          List[MiniXML](
-    //            // format: off
-    //            MiniXML.Open("a"),
-    //              MiniXML.Open("b"),
-    //                MiniXML.Open("c"),
-    //                  MiniXML.Open("c"),
-    //                  MiniXML.Close("c"),
-    //                MiniXML.Close("c"),
-    //                MiniXML.Open("d"),
-    //                MiniXML.Close("d"),
-    //                MiniXML.Open("d"),
-    //                MiniXML.Close("d"),
-    //              MiniXML.Close("b"),
-    //              MiniXML.Open("b"),
-    //                MiniXML.Open("d"),
-    //                MiniXML.Close("d"),
-    //              MiniXML.Close("b"),
-    //            MiniXML.Close("a"),
-    //            MiniXML.Open("b"),
-    //              MiniXML.Open("c"),
-    //                MiniXML.Open("c"),
-    //                MiniXML.Close("c"),
-    //              MiniXML.Close("c"),
-    //              MiniXML.Open("d"),
-    //              MiniXML.Close("d"),
-    //              MiniXML.Open("d"),
-    //              MiniXML.Close("d"),
-    //            MiniXML.Close("b"),
-    //            MiniXML.Open("c"),
-    //              MiniXML.Open("c"),
-    //              MiniXML.Close("c"),
-    //            MiniXML.Close("c"),
-    //            MiniXML.Open("c"),
-    //            MiniXML.Close("c"),
-    //            MiniXML.Open("d"),
-    //            MiniXML.Close("d"),
-    //            MiniXML.Open("a"),
-    //              MiniXML.Open("b"),
-    //                MiniXML.Open("c"),
-    //                MiniXML.Close("c"),
-    //                MiniXML.Open("d"),
-    //                MiniXML.Close("d"),
-    //              MiniXML.Close("b"),
-    //              MiniXML.Open("b"),
-    //                MiniXML.Open("d"),
-    //                MiniXML.Close("d"),
-    //              MiniXML.Close("b"),
-    //            MiniXML.Close("a"),
-    //            MiniXML.Open("b"),
-    //              MiniXML.Open("d"),
-    //              MiniXML.Close("d"),
-    //            MiniXML.Close("b"),
-    //            MiniXML.Open("d"),
-    //            MiniXML.Close("d"),
-    //            // format: on
-    //          ),
-    //          events
-    //        ))
-    //  }
+  test("more nested") {
+    MiniXQueryCompiler
+      .compile(
+        Query.ForClause(
+          "v1",
+          MiniXPath(NonEmptyList.one(Step.Descendant(Some("a")))),
+          Query.ForClause(
+            "v2",
+            MiniXPath(NonEmptyList.one(Step.Descendant(Some("b")))),
+            Query.LetClause(
+              "v3",
+              Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("c"))))),
+              Query.LetClause(
+                "v4",
+                Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("d"))))),
+                Query.Sequence(NonEmptyList
+                  .of(Query.Variable("v1"), Query.Variable("v2"), Query.Variable("v3"), Query.Variable("v4")))
+              )
+            )
+          )
+        ))
+      .esp[IO]
+      .flatMap { esp =>
+        Stream
+          .emits(
+            List[MiniXML](
+              // format: off
+              MiniXML.Open("doc"),
+                MiniXML.Open("a"),
+                  MiniXML.Open("b"),
+                    MiniXML.Open("c"),
+                      MiniXML.Open("c"),
+                      MiniXML.Close("c"),
+                    MiniXML.Close("c"),
+                    MiniXML.Open("d"),
+                    MiniXML.Close("d"),
+                    MiniXML.Open("d"),
+                    MiniXML.Close("d"),
+                  MiniXML.Close("b"),
+                  MiniXML.Open("b"),
+                    MiniXML.Open("d"),
+                    MiniXML.Close("d"),
+                  MiniXML.Close("b"),
+                MiniXML.Close("a"),
+              MiniXML.Close("doc"),
+              // format: on
+            )
+          )
+          .through(esp.pipe)
+          .compile
+          .toList
+          .map(events =>
+            expect.same(
+              List[MiniXML](
+                // format: off
+                MiniXML.Open("a"),
+                  MiniXML.Open("b"),
+                    MiniXML.Open("c"),
+                      MiniXML.Open("c"),
+                      MiniXML.Close("c"),
+                    MiniXML.Close("c"),
+                    MiniXML.Open("d"),
+                    MiniXML.Close("d"),
+                    MiniXML.Open("d"),
+                    MiniXML.Close("d"),
+                  MiniXML.Close("b"),
+                  MiniXML.Open("b"),
+                    MiniXML.Open("d"),
+                    MiniXML.Close("d"),
+                  MiniXML.Close("b"),
+                MiniXML.Close("a"),
+                MiniXML.Open("b"),
+                  MiniXML.Open("c"),
+                    MiniXML.Open("c"),
+                    MiniXML.Close("c"),
+                  MiniXML.Close("c"),
+                  MiniXML.Open("d"),
+                  MiniXML.Close("d"),
+                  MiniXML.Open("d"),
+                  MiniXML.Close("d"),
+                MiniXML.Close("b"),
+                MiniXML.Open("c"),
+                  MiniXML.Open("c"),
+                  MiniXML.Close("c"),
+                MiniXML.Close("c"),
+                MiniXML.Open("c"),
+                MiniXML.Close("c"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
+                MiniXML.Open("a"),
+                  MiniXML.Open("b"),
+                    MiniXML.Open("c"),
+                      MiniXML.Open("c"),
+                      MiniXML.Close("c"),
+                    MiniXML.Close("c"),
+                    MiniXML.Open("d"),
+                    MiniXML.Close("d"),
+                    MiniXML.Open("d"),
+                    MiniXML.Close("d"),
+                  MiniXML.Close("b"),
+                  MiniXML.Open("b"),
+                    MiniXML.Open("d"),
+                    MiniXML.Close("d"),
+                  MiniXML.Close("b"),
+                MiniXML.Close("a"),
+                MiniXML.Open("b"),
+                  MiniXML.Open("d"),
+                  MiniXML.Close("d"),
+                MiniXML.Close("b"),
+                MiniXML.Open("d"),
+                MiniXML.Close("d"),
+                // format: on
+              ),
+              events
+            ))
+      }
   }
 
 }


### PR DESCRIPTION
The common query language over tree structures, based on the technique described in [_XQuery Streaming by Forest Transducers_](https://doi.org/10.1109/ICDE.2014.6816714).

This will be used to implement compilation of jq and xquery queries.