### PR TITLE
Investigation in Scala2/Scala3 decoder inconsistency

### DIFF
--- a/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/internal/OptCellDecoder.scala
+++ b/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/internal/OptCellDecoder.scala
@@ -26,6 +26,12 @@ sealed trait OptCellDecoder[T] {
 }
 
 object OptCellDecoder extends LowPrioOptCellDecoders {
+  // left here for bincompat
+  private[internal] def makeNonOpt[A: CellDecoder]: OptCellDecoder[A] = new OptCellDecoder[A] {
+    override def apply(name: String, value: Option[String]): DecoderResult[A] =
+      value.toRight(new DecoderError(s"unknown column name '$name'")).flatMap(CellDecoder[A].apply)
+  }
+
   given makeNonOpt[A: CellDecoder](using NotGiven[A <:< Option[_]]): OptCellDecoder[A] = new OptCellDecoder[A] {
     override def apply(name: String, value: Option[String]): DecoderResult[A] =
       value.toRight(new DecoderError(s"unknown column name '$name'")).flatMap(CellDecoder[A].apply)

--- a/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/semiauto.scala
+++ b/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/semiauto.scala
@@ -44,7 +44,7 @@ object semiauto {
                 case (hd, idx) :: tail => cd(s"at index $idx", Some(hd)).tupleLeft(tail)
                 // do not fail immediately as optional decoding could succeed without input
                 case Nil => cd(s"at index -1", None).tupleLeft(Nil)
-            }
+              }.adaptErr { case d: DecoderError => d.withLine(row.line) }
         }(summon, summon, summon)
           .runA(row.values.toList.zipWithIndex)
       }
@@ -73,9 +73,9 @@ object semiauto {
               StateT[DecoderResult, List[(String, Option[String])], t] {
                 case (name, value) :: tail => cd(name, value).tupleLeft(tail)
                 case Nil                   => new DecoderError("Bug in derivation logic.").asLeft
-            }
+              }.adaptErr { case d: DecoderError => d.withLine(row.line) }
         }(summon, summon, summon)
-          .runA(names.map(name => name -> row.toMap.get(name)))
+          .runA(names.map(name => name -> row(name)))
       }
     }
   }

--- a/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
@@ -38,6 +38,12 @@ case class RowF[H[+a] <: Option[a], Header](values: NonEmptyList[String],
   /** Number of cells in the row. */
   def size: Int = values.size
 
+  /**
+    * Set the line number for this row.
+    */
+  def withLine(line: Option[Long]): RowF[H, Header] =
+    copy(line = line)
+
   /** Returns the content of the cell at `idx` if it exists.
     * Returns `None` if `idx` is out of row bounds.
     * An empty cell value results in `Some("")`.


### PR DESCRIPTION
@alycklama and I noticed in https://github.com/gnieh/fs2-data/pull/436 that certain built-in decoders have inconsistent behaviour between Scala 2 and 3.

Since this inconsistency is unrelated to our PR, we decided to make a separate issue to investigate this.

I think it is related to the Shapeless types used in the `MapShapedCsvRowDecoder`, since Shapeless makes heavy use of Macros which have changed in Scala 3. However, that is where my knowledge of Shapeless ends.

This PR adds a few unit tests that demonstrate the problem. They succeed on Scala 2 and fail on Scala 3.