### PR TITLE
Use HeaderSizeError

### DIFF
--- a/csv/shared/src/main/scala/fs2/data/csv/CsvRow.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/CsvRow.scala
@@ -26,10 +26,7 @@ object CsvRow {
                     headers: NonEmptyList[Header],
                     line: Option[Long] = None): Either[CsvException, CsvRow[Header]] =
     if (values.length =!= headers.length)
-      Left(
-        new CsvException(
-          s"Headers have size ${headers.length} but row has size ${values.length}. Both numbers must match!",
-          line))
+      Left(new HeaderSizeError(headers.length, values.length, line))
     else
       Right(new CsvRow(values, Some(headers), line))
 

--- a/csv/shared/src/main/scala/fs2/data/csv/exceptions.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/exceptions.scala
@@ -38,6 +38,12 @@ class HeaderSizeError(msg: String,
                       override val line: Option[Long] = None,
                       inner: Throwable = null)
     extends HeaderError(msg, line, inner) {
+  def this(expectedColumns: Int, actualColumns: Int, line: Option[Long]) =
+    this(s"Headers have size $expectedColumns but row has size $actualColumns. Both numbers must match!",
+         expectedColumns,
+         actualColumns,
+         line)
+
   override def withLine(line: Option[Long]): HeaderSizeError =
     new HeaderSizeError(msg, expectedColumns, actualColumns, line, inner)
 }

--- a/csv/shared/src/test/scala/fs2/data/csv/CsvParserTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/CsvParserTest.scala
@@ -149,9 +149,9 @@ object CsvParserTest extends SimpleIOSuite {
 
     val expected = List(
       Right(TestData("John Doe", 47, "description 1")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 3", None)),
+      Left(new HeaderSizeError(3, 2, Some(3L))),
       Right(TestData("Bob Smith", 80, "description 2")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 5", None))
+      Left(new HeaderSizeError(3, 2, Some(5L)))
     )
 
     val stream = Stream
@@ -178,9 +178,9 @@ object CsvParserTest extends SimpleIOSuite {
 
     val expected = List(
       Left(new DecoderError("unknown field name", None)),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 3", None)),
+      Left(new HeaderSizeError(3, 2, Some(3L))),
       Left(new DecoderError("unknown field name", None)),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 5", None))
+      Left(new HeaderSizeError(3, 2, Some(5L)))
     )
 
     val stream = Stream
@@ -207,9 +207,9 @@ object CsvParserTest extends SimpleIOSuite {
 
     val expected = List(
       Right(TestData("John Doe", 47, "description 1")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 3", None)),
+      Left(new HeaderSizeError(3, 2, Some(3L))),
       Right(TestData("Bob Smith", 80, "description 2")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 5", None))
+      Left(new HeaderSizeError(3, 2, Some(5L)))
     )
 
     val stream = Stream
@@ -238,9 +238,9 @@ object CsvParserTest extends SimpleIOSuite {
 
     val expected = List(
       Right(TestData("John Doe", 47, "description 1")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 2", None)),
+      Left(new HeaderSizeError(3, 2, Some(2L))),
       Right(TestData("Bob Smith", 80, "description 2")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 4", None))
+      Left(new HeaderSizeError(3, 2, Some(4L)))
     )
 
     val stream = Stream
@@ -341,9 +341,9 @@ object CsvParserTest extends SimpleIOSuite {
 
     val expected = List(
       Right(TestData("John Doe", 47, "description 1")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 3", None)),
+      Left(new HeaderSizeError(3, 2, Some(3L))),
       Right(TestData("Bob Smith", 80, "description 2")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 5", None))
+      Left(new HeaderSizeError(3, 2, Some(5L)))
     )
 
     val stream = Stream
@@ -370,9 +370,9 @@ object CsvParserTest extends SimpleIOSuite {
 
     val expected = List(
       Left(new DecoderError("unknown field name", None)),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 3", None)),
+      Left(new HeaderSizeError(3, 2, Some(3L))),
       Left(new DecoderError("unknown field name", None)),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 5", None))
+      Left(new HeaderSizeError(3, 2, Some(5L)))
     )
 
     val stream = Stream
@@ -399,9 +399,9 @@ object CsvParserTest extends SimpleIOSuite {
 
     val expected = List(
       Right(TestData("John Doe", 47, "description 1")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 3", None)),
+      Left(new HeaderSizeError(3, 2, Some(3L))),
       Right(TestData("Bob Smith", 80, "description 2")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 5", None))
+      Left(new HeaderSizeError(3, 2, Some(5L)))
     )
 
     val stream = Stream
@@ -430,9 +430,9 @@ object CsvParserTest extends SimpleIOSuite {
 
     val expected = List(
       Right(TestData("John Doe", 47, "description 1")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 2", None)),
+      Left(new HeaderSizeError(3, 2, Some(2L))),
       Right(TestData("Bob Smith", 80, "description 2")),
-      Left(new CsvException("Headers have size 3 but row has size 2. Both numbers must match! in line 4", None))
+      Left(new HeaderSizeError(3, 2, Some(4L)))
     )
 
     val stream = Stream


### PR DESCRIPTION
Allows to handle broken CSV files where column count mismatches more precisely than when having to match the error message.