### PR TITLE
Use java.lang.Math

### DIFF
--- a/cbor-json/shared/src/main/scala/fs2/data/cbor/package.scala
+++ b/cbor-json/shared/src/main/scala/fs2/data/cbor/package.scala
@@ -127,27 +127,27 @@ package object json {
           case CborItem.TextString(k) =>
             tokenizeValue(chunk, idx + 1, rest, tag, chunkAcc += Token.Key(k)).flatMap {
               case (chunk, idx, rest, chunkAcc) =>
-                tokenizeMap(chunk, idx, rest, tag, math.max(-1L, count - 1L), chunkAcc)
+                tokenizeMap(chunk, idx, rest, tag, Math.max(-1L, count - 1L), chunkAcc)
             }
           case CborItem.StartIndefiniteTextString =>
             tokenizeTextStrings(chunk, idx + 1, rest, new StringBuilder, chunkAcc).flatMap {
               case (chunk, idx, rest, chunkAcc, s) =>
                 tokenizeValue(chunk, idx, rest, None, chunkAcc += Token.Key(s)).flatMap {
                   case (chunk, idx, rest, chunkAcc) =>
-                    tokenizeMap(chunk, idx, rest, tag, math.max(-1L, count - 1L), chunkAcc)
+                    tokenizeMap(chunk, idx, rest, tag, Math.max(-1L, count - 1L), chunkAcc)
                 }
             }
           case CborItem.ByteString(bytes) =>
             tokenizeValue(chunk, idx + 1, rest, None, chunkAcc += Token.Key(decodeString(tag.getOrElse(-1), bytes)))
               .flatMap { case (chunk, idx, rest, chunkAcc) =>
-                tokenizeMap(chunk, idx, rest, tag, math.max(-1L, count - 1L), chunkAcc)
+                tokenizeMap(chunk, idx, rest, tag, Math.max(-1L, count - 1L), chunkAcc)
               }
           case CborItem.StartIndefiniteByteString =>
             tokenizeByteStrings(chunk, idx + 1, rest, tag.getOrElse(-1), new StringBuilder, chunkAcc).flatMap {
               case (chunk, idx, rest, chunkAcc, s) =>
                 tokenizeValue(chunk, idx, rest, None, chunkAcc += Token.Key(s)).flatMap {
                   case (chunk, idx, rest, chunkAcc) =>
-                    tokenizeMap(chunk, idx, rest, tag, math.max(-1L, count - 1L), chunkAcc)
+                    tokenizeMap(chunk, idx, rest, tag, Math.max(-1L, count - 1L), chunkAcc)
                 }
             }
           case t =>
@@ -177,7 +177,7 @@ package object json {
             Pull.pure((chunk, idx + 1, rest, chunkAcc += Token.EndArray))
           case _ =>
             tokenizeValue(chunk, idx, rest, tag, chunkAcc).flatMap { case (chunk, idx, rest, chunkAcc) =>
-              tokenizeArray(chunk, idx, rest, tag, math.max(-1L, count - 1L), chunkAcc)
+              tokenizeArray(chunk, idx, rest, tag, Math.max(-1L, count - 1L), chunkAcc)
             }
         }
       }

--- a/cbor/shared/src/main/scala/fs2/data/cbor/Diagnostic.scala
+++ b/cbor/shared/src/main/scala/fs2/data/cbor/Diagnostic.scala
@@ -80,7 +80,7 @@ object Diagnostic {
               case _ =>
                 if (!start) acc.append(", ")
                 OptionT(value(s)).flatMapF { case (str, s) =>
-                  array(s, math.max(-1L, size - 1), false, acc.append(str))
+                  array(s, Math.max(-1L, size - 1), false, acc.append(str))
                 }.value
             }
           case None => Pull.pure(None)
@@ -106,7 +106,7 @@ object Diagnostic {
                 if (!start) acc.append(", ")
                 OptionT(value(s)).flatMap { case (k, s) =>
                   OptionT(value(s)).flatMapF { case (v, s) =>
-                    map(s, math.max(-1L, size - 1), false, acc.append(k).append(": ").append(v))
+                    map(s, Math.max(-1L, size - 1), false, acc.append(k).append(": ").append(v))
                   }
                 }.value
             }

--- a/cbor/shared/src/main/scala/fs2/data/cbor/HalfFloat.scala
+++ b/cbor/shared/src/main/scala/fs2/data/cbor/HalfFloat.scala
@@ -68,11 +68,11 @@ object HalfFloat {
     val unsigned =
       if (e == 0) {
         // either zero or a subnormal number
-        if (m != 0) math.pow(2F, -14).toFloat * (m / 1024F)
+        if (m != 0) Math.pow(2F, -14).toFloat * (m / 1024F)
         else 0F
       } else if (e != 31) {
         // normal number
-        math.pow(2F, e - 15D).toFloat * (1F + m / 1024F)
+        Math.pow(2F, e - 15D).toFloat * (1F + m / 1024F)
       } else if ((raw & 1023) != 0) {
         Float.NaN
       } else {

--- a/json/src/main/scala/fs2/data/json/jsonpath/internals/JsonQueryPipe.scala
+++ b/json/src/main/scala/fs2/data/json/jsonpath/internals/JsonQueryPipe.scala
@@ -36,7 +36,7 @@ private[jsonpath] object PathMatcher {
       this.high >= that.low && this.low <= that.high
 
     def intersection(that: Range): Range =
-      Range(math.max(this.low, that.low), math.min(this.high, that.high))
+      Range(Math.max(this.low, that.low), Math.min(this.high, that.high))
 
   }
 


### PR DESCRIPTION
Replace the usage methods of Scala's math by java.lang.Math methods which are equivalent but compiled as intrinsics and hence execute much faster.

Inspired by the following Discord conversation: https://discord.com/channels/632277896739946517/839263556754472990/1077030445117624401