### PR TITLE
Generalize optional fields handling for `RowF`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
         if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
+      - name: Compile documentation
+        if: matrix.scala == '2.13.10' && matrix.project == 'rootJVM'
+        run: 'sbt ''project ${{ matrix.project }}'' ''++ ${{ matrix.scala }}'' ''set ThisBuild / tlFatalWarningsInCi := false'' documentation/mdoc'
+
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         run: mkdir -p json/.native/target json/play/.jvm/target text/native/target cbor-json/native/target finite-state/native/target target .js/target documentation/target cbor/js/target finite-state/js/target text/js/target benchmarks/.jvm/target json/play/.js/target json/.jvm/target xml/scala-xml/.native/target csv/jvm/target xml/.jvm/target xml/.js/target cbor/native/target json/circe/.native/target finite-state/jvm/target cbor-json/js/target cbor/jvm/target csv/native/target json/circe/.jvm/target .jvm/target csv/js/target csv/generic/jvm/target .native/target text/jvm/target xml/.native/target json/diffson/.native/target json/diffson/.js/target cbor-json/jvm/target json/interpolators/.jvm/target json/.js/target json/interpolators/.js/target csv/generic/js/target json/circe/.js/target json/diffson/.jvm/target xml/scala-xml/.js/target csv/generic/native/target xml/scala-xml/.jvm/target json/interpolators/.native/target project/target

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,14 @@ ThisBuild / apiURL := Some(new java.net.URL("https://fs2-data.gnieh.org/api/"))
 ThisBuild / crossScalaVersions := Seq(scala212, scala213, scala3)
 ThisBuild / scalaVersion := scala213
 
+ThisBuild / githubWorkflowBuildPostamble +=
+  WorkflowStep.Sbt(
+    List("set ThisBuild / tlFatalWarningsInCi := false", "documentation/mdoc"),
+    None,
+    Some("Compile documentation"),
+    Some(s"matrix.scala == '$scala213' && matrix.project == 'rootJVM'")
+  )
+
 val commonSettings = List(
   headerLicense := Some(HeaderLicense.ALv2("2022", "Lucas Satabin")),
   licenses += ("The Apache Software License, Version 2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")),

--- a/csv/shared/src/test/scala/fs2/data/csv/RowFTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/RowFTest.scala
@@ -33,23 +33,43 @@ object RowFTest extends SimpleIOSuite {
       expect.eql(NonEmptyList.of("a", "b", "c", "d"), extended.headers.get)
   }
 
-  pureTest("CsvRow.asNonEmpty should return None for empty cells") {
+  pureTest("CsvRow.asOptional should return None for empty cells") {
     val row = CsvRow.unsafe(NonEmptyList.of("", "2", "3"), NonEmptyList.of("a", "b", "c"))
-    expect(row.asNonEmpty[Int]("a").contains(None))
+    expect(row.asOptional[Int]("a").contains(None))
   }
 
-  pureTest("CsvRow.asNonEmpty should return decoded value for non-empty cells") {
+  pureTest("CsvRow.asOptional should return None for missing cells") {
     val row = CsvRow.unsafe(NonEmptyList.of("", "2", "3"), NonEmptyList.of("a", "b", "c"))
-    expect(row.asNonEmpty[Int]("b").contains(Some(2)))
+    expect(row.asOptional[Int]("d", missing = _ => Right(None)).contains(None))
   }
 
-  pureTest("Row.asNonEmptyAt should return None for empty cells") {
-    val row = Row(NonEmptyList.of("", "2", "3"))
-    expect(row.asNonEmptyAt[Int](0).contains(None))
+  pureTest("CsvRow.asOptional should return None for values considered empty") {
+    val row = CsvRow.unsafe(NonEmptyList.of("N/A", "2", "3"), NonEmptyList.of("a", "b", "c"))
+    expect(row.asOptional[Int]("a", isEmpty = _ == "N/A").contains(None))
   }
 
-  pureTest("Row.asNonEmptyAt should return decoded value for non-empty cells") {
+  pureTest("CsvRow.asOptional should return decoded value for non-empty cells") {
+    val row = CsvRow.unsafe(NonEmptyList.of("", "2", "3"), NonEmptyList.of("a", "b", "c"))
+    expect(row.asOptional[Int]("b").contains(Some(2)))
+  }
+
+  pureTest("Row.asOptionalAt should return None for empty cells") {
     val row = Row(NonEmptyList.of("", "2", "3"))
-    expect(row.asNonEmptyAt[Int](1).contains(Some(2)))
+    expect(row.asOptionalAt[Int](0).contains(None))
+  }
+
+  pureTest("CsvRow.asOptionalAt should return None for missing cells") {
+    val row = Row(NonEmptyList.of("", "2", "3"))
+    expect(row.asOptionalAt[Int](7, missing = _ => Right(None)).contains(None))
+  }
+
+  pureTest("CsvRow.asOptionalAt should return None for values considered empty") {
+    val row = Row(NonEmptyList.of("N/A", "2", "3"))
+    expect(row.asOptionalAt[Int](0, isEmpty = _ == "N/A").contains(None))
+  }
+
+  pureTest("Row.asOptionalAt should return decoded value for non-empty cells") {
+    val row = Row(NonEmptyList.of("", "2", "3"))
+    expect(row.asOptionalAt[Int](1).contains(Some(2)))
   }
 }

--- a/documentation/docs/json/index.md
+++ b/documentation/docs/json/index.md
@@ -107,11 +107,6 @@ The DSL is typesafe, so that you cannot write invalid selectors. Any attempt to 
 root.index(1).!
 ```
 
-```scala mdoc:fail
-// you cannot use the same flag twice
-root.index(1).?.?
-```
-
 ### AST builder and tokenizer
 
 To handle Json ASTs, you can use the types and pipes available in the `fs2.data.json.ast` package.


### PR DESCRIPTION
An optional field might be encoded in various ways, depending on the CSV data emitter. `RowF` can handle most scenarios by providing a way to define:
 - how to react when a field is not present in the dataset at all (i.e. the column is missing in the input data)
 - what values are considered empty (e.g. empty string, or `null`, or `N/A`)