### PR TITLE
Fix CSV line numbers in presence of empty rows

### DIFF
--- a/csv/shared/src/main/scala/fs2/data/csv/internals/RowParser.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/internals/RowParser.scala
@@ -127,7 +127,7 @@ private[csv] object RowParser {
                      line + 1,
                      chunkAcc += Row(NonEmptyList("", tail).reverse, Some(line)))
               } else {
-                rows(T.advance(context), currentField, Nil, State.BeginningOfField, line, chunkAcc)
+                rows(T.advance(context), currentField, Nil, State.BeginningOfField, line + 1, chunkAcc)
               }
             } else if (c == '\r') {
               rows(T.advance(context), currentField, tail, State.InUnquotedSeenCr, line, chunkAcc)

--- a/csv/shared/src/test/scala/fs2/data/csv/RowParserTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/RowParserTest.scala
@@ -1,0 +1,31 @@
+package fs2
+package data
+package csv
+
+import cats.syntax.all._
+import weaver._
+
+object RowParserTest extends SimpleIOSuite {
+
+  pureTest("Line numbers account for empty lines (#461)") {
+    val input =
+      """A,B,C
+        |D,E,F
+        |
+        |G,H,I
+        |
+        |J,K,L
+        |""".stripMargin
+
+    val result = Stream
+      .emit(input)
+      .covary[Fallible]
+      .through(lowlevel.rows[Fallible, String]())
+      .map(r => s"""${r.line.orEmpty}: ${r.values.toList.mkString}""")
+      .compile
+      .toList
+
+    expect.same(Right(List("1: ABC", "2: DEF", "4: GHI", "6: JKL")), result)
+  }
+
+}

--- a/csv/shared/src/test/scala/fs2/data/csv/RowParserTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/RowParserTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fs2
 package data
 package csv


### PR DESCRIPTION
Increment the line counter when an empty line in CSV input is parsed (resulting in now row).

Closes #461