### PR TITLE
Fix evaluation of stay moves

### DIFF
--- a/finite-state/shared/src/main/scala/fs2/data/esp/Pattern.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/Pattern.scala
@@ -66,7 +66,7 @@ object Pattern {
   implicit def PatternIsPattern[G, T]: IsPattern[Pattern[G, T], G, Tag[T]] =
     new IsPattern[Pattern[G, T], G, Tag[T]] {
 
-      override val trueTag: Tag[T] = Tag.True
+      override val trueTag: Tag[T] = Tag.Open
 
       override def decompose(pat: Pattern[G, T]): List[RawSkeleton[G, Tag[T]]] =
         decompose(pat, None)

--- a/finite-state/shared/src/main/scala/fs2/data/esp/Tag.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/Tag.scala
@@ -31,14 +31,13 @@ object Tag {
   case object End extends Tag[Nothing]
   case object Leaf extends Tag[Nothing]
   case class Value[T](v: T) extends Tag[T]
-  case object True extends Tag[Nothing]
 
   implicit def TagIsTag[T]: IsTag[Tag[T]] = new IsTag[Tag[T]] {
 
     def isOpen(tag: Tag[T]) =
       tag match {
-        case Input | Open | Close | Leaf | End | True => false
-        case _                                        => true
+        case Input | Open | Close | Leaf | End => false
+        case _                                 => true
       }
 
     override def eqv(x: Tag[T], y: Tag[T]): Boolean =
@@ -51,7 +50,6 @@ object Tag {
         case Close => Iterator(Close)
         case Leaf  => Iterator(Leaf)
         case End   => Iterator(End)
-        case True  => Iterator(True)
         case _     => Iterator.empty
       }
 
@@ -67,7 +65,6 @@ object Tag {
     case End        => "$"
     case Leaf       => "%"
     case Value(v)   => show"$v"
-    case True       => "true"
   }
 
   implicit def order[T: Order]: Order[Tag[T]] = Order.from {
@@ -82,8 +79,6 @@ object Tag {
     case (Value(_), Leaf)                          => -1
     case (Leaf, Value(_) | Name(_) | Open | Close) => 1
     case (Leaf, _)                                 => -1
-    case (_, True)                                 => -1
-    case (True, _)                                 => 1
     case (_, _)                                    => 1
   }
 

--- a/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
@@ -18,12 +18,12 @@ package fs2
 package data
 package mft
 
-import esp.{Depth, ESP, Rhs => ERhs, Pattern, PatternDsl, Tag => ETag}
-
-import cats.{Defer, MonadError}
 import cats.syntax.all._
-import cats.Show
+import cats.{Defer, MonadError, Show}
+
 import scala.annotation.tailrec
+
+import esp.{Depth, ESP, Rhs => ERhs, Pattern, PatternDsl, Tag => ETag}
 
 sealed trait Forest
 object Forest {
@@ -220,6 +220,7 @@ private[data] class MFT[Guard, InTag, OutTag](init: Int, val rules: Map[Int, Rul
     * that are never called from the initial state.
     */
   def removeUnreachableStates: MFT[Guard, InTag, OutTag] = {
+    @tailrec
     def reachable(toProcess: List[Int], processed: Set[Int]): Set[Int] =
       toProcess match {
         case q :: qs =>

--- a/finite-state/shared/src/main/scala/fs2/data/mft/query/QueryCompiler.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/query/QueryCompiler.scala
@@ -58,7 +58,7 @@ private[fs2] abstract class QueryCompiler[Tag, Path] {
   /** Return the constructor tag of this pattern, or `None` if it is a wildcard. */
   def tagOf(pattern: Pattern): Option[Tag]
 
-  def compile(query: Query[Tag, Path]): MFT[NonEmptyList[Guard], Tag, Tag] = {
+  def compile(query: Query[Tag, Path], credit: Int = 50): MFT[NonEmptyList[Guard], Tag, Tag] = {
     val mft = dsl[NonEmptyList[Guard], Tag, Tag] { implicit builder =>
       val q0 = state(args = 0, initial = true)
       val qinit = state(args = 1)
@@ -211,7 +211,7 @@ private[fs2] abstract class QueryCompiler[Tag, Path] {
       } else {
         mft
       }
-    optimize(mft, 50)
+    optimize(mft, credit)
   }
 
 }

--- a/finite-state/shared/src/main/scala/fs2/data/pattern/Selector.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/pattern/Selector.scala
@@ -16,7 +16,8 @@
 
 package fs2.data.pattern
 
-import cats.syntax.either._
+import cats.Show
+import cats.syntax.all._
 
 import scala.annotation.tailrec
 
@@ -39,4 +40,10 @@ object Selector {
   case class Root[Expr, Tag]() extends Selector[Expr, Tag]
   case class Cons[Expr, Tag](sel: Selector[Expr, Tag], tag: Tag, n: Int) extends Selector[Expr, Tag]
   case class Guard[Expr, Tag](sel: Selector[Expr, Tag], expr: Expr) extends Selector[Expr, Tag]
+
+  implicit def show[E: Show, T: Show]: Show[Selector[E, T]] = _ match {
+    case Root()            => "$"
+    case Cons(sel, tag, n) => show"$sel.$tag.$n"
+    case Guard(sel, expr)  => show"$sel if $expr"
+  }
 }

--- a/finite-state/shared/src/test/scala/fs2/data/esp/DupSpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/esp/DupSpec.scala
@@ -18,12 +18,11 @@ package fs2
 package data
 package esp
 
-import mft._
-
 import cats.effect._
-
-import weaver._
 import fs2.data.pattern._
+import weaver._
+
+import mft._
 
 object DupSpec extends IOSuite {
 

--- a/finite-state/shared/src/test/scala/fs2/data/esp/ESPSpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/esp/ESPSpec.scala
@@ -32,9 +32,9 @@ object NodeGuard {
 
     override def eval(guard: NodeGuard, tree: ConstructorTree[Tag[String]]): Option[Tag[String]] =
       tree match {
-        case ConstructorTree(Tag.Name(n), _) => (guard.names.contains(n) == guard.positive).guard[Option].as(Tag.True)
+        case ConstructorTree(Tag.Name(n), _) => (guard.names.contains(n) == guard.positive).guard[Option].as(Tag.Open)
         case ConstructorTree(Tag.Open, List(ConstructorTree(Tag.Name(n), _))) =>
-          (guard.names.contains(n) == guard.positive).guard[Option].as(Tag.True)
+          (guard.names.contains(n) == guard.positive).guard[Option].as(Tag.Open)
         case _ => None
       }
 
@@ -69,7 +69,7 @@ object ESPSpec extends IOSuite {
 
   type Res = ESP[IO, NodeGuard, String, String]
 
-  override def sharedResource: Resource[IO, Res] = Resource.eval(mft.esp).evalTap(IO.println(_))
+  override def sharedResource: Resource[IO, Res] = Resource.eval(mft.esp)
 
   test("reverse tree") { esp =>
     Stream

--- a/finite-state/shared/src/test/scala/fs2/data/esp/ESPSpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/esp/ESPSpec.scala
@@ -69,7 +69,7 @@ object ESPSpec extends IOSuite {
 
   type Res = ESP[IO, NodeGuard, String, String]
 
-  override def sharedResource: Resource[IO, Res] = Resource.eval(mft.esp)
+  override def sharedResource: Resource[IO, Res] = Resource.eval(mft.esp).evalTap(IO.println(_))
 
   test("reverse tree") { esp =>
     Stream

--- a/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
@@ -47,8 +47,8 @@ object QuerySpec extends SimpleIOSuite {
     override def eval(guard: NonEmptyList[Set[String]], tree: ConstructorTree[Tag[String]]): Option[Tag[String]] =
       tree match {
         case ConstructorTree(Tag.Open, List(ConstructorTree(Tag.Name(n), _))) if guard.forall(_.contains(n)) =>
-          Some(Tag.True)
-        case ConstructorTree(Tag.Name(n), _) if guard.forall(_.contains(n)) => Some(Tag.True)
+          Some(Tag.Open)
+        case ConstructorTree(Tag.Name(n), _) if guard.forall(_.contains(n)) => Some(Tag.Open)
         case _                                                              => None
       }
 

--- a/finite-state/shared/src/test/scala/fs2/data/pattern/PatGuardSpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/pattern/PatGuardSpec.scala
@@ -30,8 +30,8 @@ object PatGuardSpec extends IOSuite {
   implicit object evaluator extends Evaluator[Set[String], Tag[String]] {
     def eval(guard: Set[String], tree: ConstructorTree[Tag[String]]): Option[Tag[String]] =
       tree match {
-        case ConstructorTree(Tag.Open, List(ConstructorTree(Tag.Name(n), _))) if guard.contains(n) => Some(Tag.True)
-        case ConstructorTree(Tag.Name(n), _) if guard.contains(n)                                  => Some(Tag.True)
+        case ConstructorTree(Tag.Open, List(ConstructorTree(Tag.Name(n), _))) if guard.contains(n) => Some(Tag.Open)
+        case ConstructorTree(Tag.Name(n), _) if guard.contains(n)                                  => Some(Tag.Open)
         case _                                                                                     => None
       }
   }


### PR DESCRIPTION
Stay moves appear in MFT (and ESP) RHSs when a state is called on the `Self` forest. This results in the event stream processor to immediately call the state on the currently processed event. This is similar to calling a standard state on the child or next forest, but differs in the way it must evaluate the arguments.

In a standard call, the arguments must be stepped to resolve potentially nested (non self) calls. However when resolving a self call we should not apply standard calls, which should only be processed in the next step.

This is fixed in this PR.

Also this PR improves the code by:
 - using a `Vector[Expr[Out]` representation for state parameters instead of a `Map[Int, Expr[Out]]`
 - inlining more stay moves