### PR TITLE
Add a default fallback value to paths

### DIFF
--- a/finite-state/shared/src/main/scala/fs2/data/mft/query/Query.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/query/Query.scala
@@ -29,7 +29,7 @@ object Query {
   case class ForClause[Tag, Path](variable: String, source: Path, result: Query[Tag, Path]) extends Query[Tag, Path]
   case class LetClause[Tag, Path](variable: String, query: Query[Tag, Path], result: Query[Tag, Path])
       extends Query[Tag, Path]
-  case class Ordpath[Tag, Path](path: Path) extends Query[Tag, Path]
+  case class Ordpath[Tag, Path](path: Path, default: Option[Tag]) extends Query[Tag, Path]
   case class Variable[Tag, Path](name: String) extends Query[Tag, Path]
   case class Node[Tag, Path](tag: Tag, child: Query[Tag, Path]) extends Query[Tag, Path]
   case class Leaf[Tag, Path](tag: Tag) extends Query[Tag, Path]

--- a/finite-state/shared/src/main/scala/fs2/data/pfsa/PDFA.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/pfsa/PDFA.scala
@@ -21,8 +21,10 @@ import cats.syntax.foldable._
 
 import Pred.syntax._
 
-private[data] class PDFA[P, T](val init: Int, val finals: Set[Int], val transitions: Array[List[(P, Int)]])(implicit
-    P: Pred[P, T]) {
+private[data] class PDFA[P, T](val init: Int,
+                               val finals: Set[Int],
+                               val trap: Option[Int],
+                               val transitions: Array[List[(P, Int)]])(implicit P: Pred[P, T]) {
 
   def step(q: Int, t: T): Option[Int] =
     if (q >= transitions.length)

--- a/finite-state/shared/src/main/scala/fs2/data/pfsa/PNFA.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/pfsa/PNFA.scala
@@ -76,6 +76,7 @@ private[data] class PNFA[P, T](val init: Int, val finals: Set[Int], val transiti
         case Nil =>
           new PDFA[P, T](0,
                          newFinals.map(newStates(_)),
+                         None,
                          newTransitions.result().map(_.map { case (p, q) => (p, newStates(q)) }))
         case q :: qs =>
           if (newStates.contains(q)) {

--- a/finite-state/shared/src/main/scala/fs2/data/pfsa/Regular.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/pfsa/Regular.scala
@@ -194,8 +194,10 @@ sealed abstract class Regular[CharSet] {
     }
 
     val (qs, transitions) = explore(Chain.one(this), Map.empty, this)
-    val finals = qs.zipWithIndex.collect { case (re, idx) if re.acceptEpsilon => idx }.toList.toSet
-    new PDFA[CharSet, C](0, finals, Array.tabulate(qs.size.toInt)(transitions.getOrElse(_, Nil)))
+    val indexedStates = qs.zipWithIndex
+    val finals = indexedStates.collect { case (re, idx) if re.acceptEpsilon => idx }.toList.toSet
+    val trap = indexedStates.collectFirst { case (Regular.Chars(cs), idx) if cs === never => idx }
+    new PDFA[CharSet, C](0, finals, trap, Array.tabulate(qs.size.toInt)(transitions.getOrElse(_, Nil)))
   }
 
 }

--- a/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
+++ b/finite-state/shared/src/test/scala/fs2/data/mft/QuerySpec.scala
@@ -116,7 +116,7 @@ abstract class QuerySpec(credit: Int) extends SimpleIOSuite {
 
   test("child path") {
     MiniXQueryCompiler
-      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(Some("a"))))), credit)
+      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(Some("a")))), None), credit)
       .esp[IO]
       .flatMap { esp =>
         Stream
@@ -163,7 +163,7 @@ abstract class QuerySpec(credit: Int) extends SimpleIOSuite {
 
   test("any child path") {
     MiniXQueryCompiler
-      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(None)))), credit)
+      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Child(None))), None), credit)
       .esp[IO]
       .flatMap { esp =>
         Stream
@@ -210,7 +210,7 @@ abstract class QuerySpec(credit: Int) extends SimpleIOSuite {
 
   test("descendant path") {
     MiniXQueryCompiler
-      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a"))))), credit)
+      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a")))), None), credit)
       .esp[IO]
       .flatMap { esp =>
         Stream
@@ -267,7 +267,7 @@ abstract class QuerySpec(credit: Int) extends SimpleIOSuite {
 
   test("any descendant path") {
     MiniXQueryCompiler
-      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(None)))), credit)
+      .compile(Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(None))), None), credit)
       .esp[IO]
       .flatMap { esp =>
         Stream
@@ -326,10 +326,11 @@ abstract class QuerySpec(credit: Int) extends SimpleIOSuite {
 
   test("simple let") {
     MiniXQueryCompiler
-      .compile(
-        Query
-          .LetClause("v", Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a"))))), Query.Variable("v")),
-        credit)
+      .compile(Query
+                 .LetClause("v",
+                            Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a")))), None),
+                            Query.Variable("v")),
+               credit)
       .esp[IO]
       .flatMap { esp =>
         Stream
@@ -662,10 +663,10 @@ abstract class QuerySpec(credit: Int) extends SimpleIOSuite {
               MiniXPath(NonEmptyList.one(Step.Descendant(Some("b")))),
               Query.LetClause(
                 "v3",
-                Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("c"))))),
+                Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("c")))), None),
                 Query.LetClause(
                   "v4",
-                  Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("d"))))),
+                  Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("d")))), None),
                   Query.Sequence(NonEmptyList
                     .of(Query.Variable("v1"), Query.Variable("v2"), Query.Variable("v3"), Query.Variable("v4")))
                 )
@@ -781,7 +782,7 @@ abstract class QuerySpec(credit: Int) extends SimpleIOSuite {
         .compile(
           Query.LetClause(
             "a",
-            Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a"))))),
+            Query.Ordpath(MiniXPath(NonEmptyList.one(Step.Descendant(Some("a")))), None),
             Query.ForClause(
               "b",
               MiniXPath(NonEmptyList.one(Step.Descendant(Some("b")))),


### PR DESCRIPTION
In some query languages and for some formats, when a path is not found, it is fine to output nothing. For instance for XML, an empty sequence of nodes is ok.

However in some cases, a default value has to be output. This is the case in the JSON query language. When the query builds an object whose value is a sub-query, then the value cannot be empty, even if the sub-query finds no element. Moreover, the query must return exactly one result. If it return zero or more than one element, then the generated JSON data is invalid.

But in the JSON query lanuage, generating no data is still valid, and happens when the path is iterated over, for instance.

This change allows for the query to parameterize for each path whether it should return a (unique) default value, or not. If not, then the previous behavior is kept, otherwise in case of no-match, then the default value is output.