### PR TITLE
Fix default value

### DIFF
--- a/finite-state/shared/src/main/scala/fs2/data/esp/Expr.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/Expr.scala
@@ -22,29 +22,35 @@ import cats.syntax.show._
 
 sealed trait Expr[+Out]
 object Expr {
-  case class Call[Out](q: Int, depth: Int, params: List[Expr[Out]]) extends Expr[Out]
+  case class Call[Out](q: Int, depth: Int, params: List[Expr[Out]], next: Expr[Out]) extends Expr[Out]
   case object Epsilon extends Expr[Nothing]
   case class Open[Out](open: Out, next: Expr[Out]) extends Expr[Out]
   case class Close[Out](close: Out, next: Expr[Out]) extends Expr[Out]
   case class Leaf[Out](value: Out, next: Expr[Out]) extends Expr[Out]
-  case class Concat[Out](fst: Expr[Out], snd: Expr[Out]) extends Expr[Out]
+  case class Default[Out](v: Out, next: Expr[Out]) extends Expr[Out]
 
   def concat[Out](e1: Expr[Out], e2: Expr[Out]): Expr[Out] =
     (e1, e2) match {
-      case (Epsilon, _)           => e2
-      case (_, Epsilon)           => e1
-      case (Open(o, Epsilon), _)  => Open(o, e2)
-      case (Close(c, Epsilon), _) => Close(c, e2)
-      case (Leaf(v, Epsilon), _)  => Leaf(v, e2)
-      case (_, _)                 => Concat(e1, e2)
+      case (Epsilon, _)                => e2
+      case (_, Epsilon)                => e1
+      case (Call(q, d, p, Epsilon), _) => Call(q, d, p, e2)
+      case (Call(q, d, p, e1), _)      => Call(q, d, p, concat(e1, e2))
+      case (Default(v, Epsilon), _)    => Default(v, e2)
+      case (Default(v, e1), _)         => Default(v, concat(e1, e2))
+      case (Open(o, Epsilon), _)       => Open(o, e2)
+      case (Open(o, e1), _)            => Open(o, concat(e1, e2))
+      case (Close(c, Epsilon), _)      => Close(c, e2)
+      case (Close(c, e1), _)           => Close(c, concat(e1, e2))
+      case (Leaf(v, Epsilon), _)       => Leaf(v, e2)
+      case (Leaf(v, e1), _)            => Leaf(v, concat(e1, e2))
     }
 
   implicit def show[Out: Show]: Show[Expr[Out]] = Show.show {
-    case Call(q, d, ps) => show"q${q}_$d(${(ps: List[Expr[Out]]).mkString_(", ")})"
-    case Epsilon        => ""
-    case Open(o, next)  => show"$o $next"
-    case Close(c, next) => show"$c $next"
-    case Leaf(l, next)  => show"$l $next"
-    case Concat(e1, e2) => show"$e1 $e2"
+    case Call(q, d, ps, next) => show"q${q}_$d(${(ps: List[Expr[Out]]).mkString_(", ")}) $next"
+    case Epsilon              => ""
+    case Open(o, next)        => show"$o $next"
+    case Close(c, next)       => show"$c $next"
+    case Leaf(l, next)        => show"$l $next"
+    case Default(v, next)     => show"($v)? $next"
   }
 }

--- a/finite-state/shared/src/main/scala/fs2/data/esp/Rhs.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/esp/Rhs.scala
@@ -40,6 +40,9 @@ object Rhs {
   /** Empty RHS. */
   case object Epsilon extends Rhs[Nothing]
 
+  /** Default RHS. Value is used only if the result would be epsilon */
+  case class Default[T](v: T) extends Rhs[T]
+
   /** Builds a tree. */
   case class Tree[OutTag](tag: OutTag, inner: Rhs[OutTag]) extends Rhs[OutTag]
 
@@ -73,6 +76,7 @@ object Rhs {
     case ApplyToLeaf(_)      => "$f(%)"
     case Concat(fst, snd)    => show"$fst $snd"
     case Epsilon             => ""
+    case Default(v)          => show"($v)?"
   }
 
 }

--- a/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/MFT.scala
@@ -58,6 +58,7 @@ sealed trait Rhs[+OutTag] {
 object Rhs {
   case class Call[OutTag](q: Int, x: Forest, parameters: List[Rhs[OutTag]]) extends Rhs[OutTag]
   case object Epsilon extends Rhs[Nothing]
+  case class Default[OutTag](v: OutTag) extends Rhs[OutTag]
   case class Param(n: Int) extends Rhs[Nothing]
   case class Node[OutTag](tag: OutTag, children: Rhs[OutTag]) extends Rhs[OutTag]
   case class CopyNode[OutTag](children: Rhs[OutTag]) extends Rhs[OutTag]
@@ -71,6 +72,7 @@ object Rhs {
       case Call(q, x, Nil)     => show"q$q($x)"
       case Call(q, x, ps)      => show"q$q($x${(ps: List[Rhs[O]]).mkString_(", ", ", ", "")})"
       case Epsilon             => ""
+      case Default(v)          => show"($v)?"
       case Param(i)            => show"y$i"
       case Node(tag, children) => show"<$tag>($children)"
       case CopyNode(children)  => show"%t($children)"
@@ -262,6 +264,7 @@ private[data] class MFT[Guard, InTag, OutTag](init: Int, val rules: Map[Int, Rul
         case Rhs.Call(q, Forest.Second, params) => ERhs.Call(q, Depth.Value(1), params.map(translateRhs(_)))
         case Rhs.Param(i)                       => ERhs.Param(i)
         case Rhs.Epsilon                        => ERhs.Epsilon
+        case Rhs.Default(v)                     => ERhs.Default(v)
         case Rhs.Node(tag, inner)               => ERhs.Tree(tag, translateRhs(inner))
         case Rhs.CopyNode(inner)                => ERhs.CapturedTree(translateRhs(inner))
         case Rhs.Leaf(v)                        => ERhs.Leaf(v)

--- a/finite-state/shared/src/main/scala/fs2/data/mft/package.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/mft/package.scala
@@ -76,6 +76,9 @@ package object mft {
   def leaf[OutTag](out: OutTag): Rhs[OutTag] =
     Rhs.Leaf(out)
 
+  def default[OutTag](out: OutTag): Rhs[OutTag] =
+    Rhs.Default(out)
+
   def copy: Rhs[Nothing] =
     Rhs.CopyLeaf
 

--- a/json/src/main/scala/fs2/data/json/jq/internal/ESPCompiledJq.scala
+++ b/json/src/main/scala/fs2/data/json/jq/internal/ESPCompiledJq.scala
@@ -28,7 +28,7 @@ private[jq] class ESPCompiledJq[F[_]: RaiseThrowable](val esp: JqESP[F]) extends
 
   def apply(in: Stream[F, Token]): Stream[F, Token] =
     in.through(JsonTagger.pipe)
-      .through(esp.pipe)
+      .through(esp.pipe[TaggedJson, TaggedJson])
       .map(untag(_))
       .unNone
 

--- a/json/src/main/scala/fs2/data/json/tagged/JsonTagger.scala
+++ b/json/src/main/scala/fs2/data/json/tagged/JsonTagger.scala
@@ -19,9 +19,10 @@ package data
 package json
 package tagged
 
-import scala.collection.mutable.ListBuffer
 import cats.Show
 import cats.syntax.all._
+
+import scala.collection.mutable.ListBuffer
 
 private[json] sealed trait TaggedJson
 private[json] object TaggedJson {

--- a/json/src/test/scala/fs2/data/json/jq/JqSpec.scala
+++ b/json/src/test/scala/fs2/data/json/jq/JqSpec.scala
@@ -421,4 +421,40 @@ object JqSpec extends SimpleIOSuite {
     )
   }
 
+  test("documentation") {
+    val source = json"""{
+      "field1": 0,
+      "field2": "test",
+      "field3": [1, 2, 3]
+    }""".lift[IO]
+    for {
+      compiled <- compiler.compile(jq"""[ { "field2": .field2, "field3": .field3[] } ]""")
+      result <- source.through(compiled).compile.toList
+    } yield expect.same(
+      List(
+        Token.StartArray,
+        Token.StartObject,
+        Token.Key("field2"),
+        Token.StringValue("test"),
+        Token.Key("field3"),
+        Token.NumberValue("1"),
+        Token.EndObject,
+        Token.StartObject,
+        Token.Key("field2"),
+        Token.StringValue("test"),
+        Token.Key("field3"),
+        Token.NumberValue("2"),
+        Token.EndObject,
+        Token.StartObject,
+        Token.Key("field2"),
+        Token.StringValue("test"),
+        Token.Key("field3"),
+        Token.NumberValue("3"),
+        Token.EndObject,
+        Token.EndArray
+      ),
+      result
+    )
+  }
+
 }


### PR DESCRIPTION
Fixes the problem that the default is emitted in objects if the first field is not matching.

Now the default constructor is a first class citizen throughout the process. It is emitted only if it is not followed by a value constructor in the stream processor.