### PR TITLE
Add streaming pretty printing utilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,6 +120,9 @@ lazy val text = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "fs2-data-text",
     description := "Utilities for textual data format",
+    libraryDependencies ++= List(
+      "org.typelevel" %%% "cats-collections-core" % "0.9.8"
+    ),
     mimaBinaryIssueFilters ++= List(
       // private class
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.data.text.CharLikeCharChunks.create"),

--- a/examples/jqlike/src/main/scala/fs2/data/example/jqlike/JqLike.scala
+++ b/examples/jqlike/src/main/scala/fs2/data/example/jqlike/JqLike.scala
@@ -60,7 +60,7 @@ object JqLike extends CommandIOApp(name = "fs2-jq", header = "A streaming implem
             // execute the compiled query on the input
             .through(compiled)
             // render the query result
-            .through(render.pretty())
+            .through(render.prettyPrint())
             // encode the result
             .through(fs2.text.utf8.encode[IO])
             // and save it to the output

--- a/json/src/main/scala/fs2/data/json/package.scala
+++ b/json/src/main/scala/fs2/data/json/package.scala
@@ -166,7 +166,7 @@ package object json {
       */
     @deprecated(message = "Consider using `fs2.data.json.render.prettyPrint` instead.", since = "fs2-data 1.11.0")
     def pretty[F[_]](indent: String = "  "): Pipe[F, Token, String] =
-      _.through(fs2.data.text.render.pretty(width = 0)(Token.compact))
+      Renderer.pipe[F](true, indent)
 
     /** Renders a pretty-printed representation of the token stream with the given
       * indentation size and page width.

--- a/json/src/main/scala/fs2/data/json/package.scala
+++ b/json/src/main/scala/fs2/data/json/package.scala
@@ -22,6 +22,7 @@ import json.ast._
 import json.internals._
 
 import cats._
+import fs2.data.text.render.Renderable
 
 /** Handles stream parsing and traversing of json documents.
   */
@@ -153,7 +154,7 @@ package object json {
       * You can use this to write the Json stream to a file.
       */
     def compact[F[_]]: Pipe[F, Token, String] =
-      Renderer.pipe[F](false, "")
+      _.through(fs2.data.text.render.pretty(width = Int.MaxValue)(Token.compact))
 
     /** Renders a pretty-printed representation of the token stream with the given
       * indentation size.
@@ -163,8 +164,25 @@ package object json {
       *
       * You can use this to write the Json stream to a file.
       */
+    @deprecated(message = "Consider using `fs2.data.json.render.prettyPrint` instead.", since = "fs2-data 1.11.0")
     def pretty[F[_]](indent: String = "  "): Pipe[F, Token, String] =
-      Renderer.pipe[F](true, indent)
+      _.through(fs2.data.text.render.pretty(width = 0)(Token.compact))
+
+    /** Renders a pretty-printed representation of the token stream with the given
+      * indentation size and page width.
+      *
+      * Chunks can be concatenated to render all values in the stream,
+      * separated by new lines.
+      *
+      * You can use this to write the Json stream to a file.
+      *
+      * You can configure how the stream is rendered by providing an instance of
+      * [[fs2.data.text.render.Renderable Renderable]] in scope. A default one is automatically
+      * provided if you do not need specific formatting.
+      */
+    def prettyPrint[F[_]](width: Int = 100, indent: Int = 2)(implicit
+        renderable: Renderable[Token]): Pipe[F, Token, String] =
+      _.through(fs2.data.text.render.pretty(width = width, indent = indent))
 
   }
 
@@ -187,6 +205,8 @@ package object json {
       *
       * Top-level values are separated by new lines.
       */
+    @deprecated(message = "Consider using `.through(fs2.data.json.render.prettyPrint()).compile.string` instead.",
+                since = "fs2-data 1.11.0")
     def pretty(indent: String = "  "): Collector.Aux[Token, String] =
       new Collector[Token] {
         type Out = String

--- a/json/src/main/scala/fs2/data/json/tokens.scala
+++ b/json/src/main/scala/fs2/data/json/tokens.scala
@@ -18,9 +18,16 @@ package fs2
 package data
 package json
 
+import fs2.Pure
+import fs2.data.text.render.{DocEvent, Renderable, Renderer}
+
+import scala.annotation.switch
+import scala.annotation.tailrec
+
 sealed abstract class Token(val kind: String) {
   def jsonRepr: String
 }
+
 object Token {
 
   case object StartObject extends Token("object") {
@@ -55,7 +62,298 @@ object Token {
     def jsonRepr: String = value
   }
   case class StringValue(value: String) extends Token("string") {
-    def jsonRepr: String = s""""$value""""
+    def jsonRepr: String = {
+      val rendered = new StringBuilder
+      rendered.append('"')
+      renderString(value, 0, rendered)
+      rendered.append('"')
+      rendered.result()
+    }
+  }
+
+  private final val hex = "0123456789abcdef"
+
+  @tailrec
+  def renderString(s: String, idx: Int, builder: StringBuilder): Unit =
+    if (idx < s.length) {
+      val nextEscape = s.indexWhere(c => c > 127 || Character.isISOControl(c) || "\\/\b\f\n\r\t\"".contains(c), idx)
+      if (nextEscape >= 0) {
+        if (nextEscape > 0) {
+          builder.append(s.substring(idx, nextEscape))
+        }
+        val c = s(nextEscape)
+        (c: @switch) match {
+          case '\\' =>
+            builder.append("\\\\")
+          case '/' =>
+            builder.append("\\/")
+          case '\b' =>
+            builder.append("\\b")
+          case '\f' =>
+            builder.append("\\f")
+          case '\n' =>
+            builder.append("\\n")
+          case '\r' =>
+            builder.append("\\r")
+          case '\t' =>
+            builder.append("\\t")
+          case '"' =>
+            builder.append("\\\"")
+          case _ =>
+            // escape non ascii or control characters
+            builder
+              .append("\\u")
+              .append(hex((c >> 12) & 0x0f))
+              .append(hex((c >> 8) & 0x0f))
+              .append(hex((c >> 4) & 0x0f))
+              .append(hex(c & 0x0f))
+        }
+        renderString(s, nextEscape + 1, builder)
+      } else {
+        // append the rest of the string and we are done
+        builder.append(s.substring(idx))
+      }
+    }
+
+  private val nullValue =
+    Stream.emit(DocEvent.Text("null"))
+
+  private val trueValue =
+    Stream.emit(DocEvent.Text("true"))
+
+  private val falseValue =
+    Stream.emit(DocEvent.Text("false"))
+
+  private final val FirstObjectKey = 0
+  private final val ObjectKey = 1
+  private final val ObjectValue = 2
+  private final val FirstArrayValue = 3
+  private final val ArrayValue = 4
+
+  implicit object renderable extends Renderable[Token] {
+
+    private val startObject =
+      Stream.emits(DocEvent.GroupBegin :: DocEvent.Text("{") :: Nil)
+
+    private val endEmptyObject =
+      Stream.emits(DocEvent.Text("}") :: DocEvent.GroupEnd :: Nil)
+
+    private val endObject =
+      Stream.emits(DocEvent.GroupEnd :: DocEvent.IndentEnd :: DocEvent.LineBreak :: Nil) ++ endEmptyObject
+
+    private val startArray =
+      Stream.emits(DocEvent.GroupBegin :: DocEvent.Text("[") :: Nil)
+
+    private val endEmptyArray =
+      Stream.emits(DocEvent.Text("]") :: DocEvent.GroupEnd :: Nil)
+
+    private val endArray =
+      Stream.emits(DocEvent.GroupEnd :: DocEvent.IndentEnd :: DocEvent.LineBreak :: Nil) ++ endEmptyArray
+
+    private val objectSep =
+      Stream.emits(DocEvent.Text(",") :: DocEvent.GroupEnd :: DocEvent.Line :: Nil)
+
+    private val arraySep =
+      Stream.emits(DocEvent.Text(",") :: DocEvent.GroupEnd :: DocEvent.Line :: DocEvent.GroupBegin :: Nil)
+
+    override def newRenderer(): Renderer[Token] = new Renderer[Token] {
+
+      // the current stack of states, helping to deal with comma and indentation
+      // states are described right above
+      private[this] var states = List.empty[Int]
+
+      private def separator(): Stream[Pure, DocEvent] =
+        states match {
+          case Nil =>
+            Stream.empty
+          case state :: rest =>
+            (state: @switch) match {
+              case FirstObjectKey =>
+                states = ObjectValue :: rest
+                Stream.emits(DocEvent.IndentBegin :: DocEvent.LineBreak :: Nil)
+              case ObjectKey =>
+                states = ObjectValue :: rest
+                objectSep
+              case ObjectValue =>
+                states = ObjectKey :: rest
+                Stream.emit(DocEvent.GroupBegin)
+              case FirstArrayValue =>
+                states = ArrayValue :: rest
+                Stream.emits(DocEvent.IndentBegin :: DocEvent.LineBreak :: DocEvent.GroupBegin :: Nil)
+              case ArrayValue =>
+                states = ArrayValue :: rest
+                arraySep
+            }
+        }
+
+      private def closeObject(): Stream[Pure, DocEvent] =
+        states match {
+          case Nil => endEmptyObject
+          case state :: rest =>
+            states = rest
+            (state: @switch) match {
+              case FirstObjectKey => endEmptyObject
+              case ObjectKey      => endObject
+            }
+        }
+
+      private def closeArray(): Stream[Pure, DocEvent] =
+        states match {
+          case Nil => endEmptyArray
+          case state :: rest =>
+            states = rest
+            (state: @switch) match {
+              case FirstArrayValue => endEmptyArray
+              case ArrayValue      => endArray
+            }
+        }
+
+      override def doc(token: Token): Stream[Pure, DocEvent] =
+        token match {
+          case StartObject =>
+            val res = separator() ++ startObject
+            states = FirstObjectKey :: states
+            res
+          case EndObject =>
+            closeObject()
+          case StartArray =>
+            val res = separator() ++ startArray
+            states = FirstArrayValue :: states
+            res
+          case EndArray =>
+            closeArray()
+          case Key(value) =>
+            val rendered = new StringBuilder
+            rendered.append('"')
+            renderString(value, 0, rendered)
+            rendered.append("\": ")
+            separator() ++ Stream.emit(DocEvent.Text(rendered.result()))
+          case NullValue =>
+            separator() ++ nullValue
+          case TrueValue =>
+            separator() ++ trueValue
+          case FalseValue =>
+            separator() ++ falseValue
+          case NumberValue(value) =>
+            separator() ++ Stream.emit(DocEvent.Text(value))
+          case StringValue(value) =>
+            val rendered = new StringBuilder
+            rendered.append('"')
+            renderString(value, 0, rendered)
+            rendered.append('"')
+            separator() ++ Stream.emit(DocEvent.Text(rendered.result()))
+        }
+    }
+
+  }
+
+  /** A compact version of the JSON rendering with no space or new lines. */
+  object compact extends Renderable[Token] {
+
+    private val startObject =
+      Stream.emit(DocEvent.Text("{"))
+
+    private val endObject =
+      Stream.emit(DocEvent.Text("}"))
+
+    private val startArray =
+      Stream.emit(DocEvent.Text("["))
+
+    private val endArray =
+      Stream.emit(DocEvent.Text("]"))
+
+    private val sep =
+      Stream.emit(DocEvent.Text(","))
+
+    override def newRenderer(): Renderer[Token] = new Renderer[Token] {
+
+      // the current stack of states, helping to deal with comma and indentation
+      // states are described right above
+      private[this] var states = List.empty[Int]
+
+      private def separator(): Stream[Pure, DocEvent] =
+        states match {
+          case Nil =>
+            Stream.empty
+          case state :: rest =>
+            (state: @switch) match {
+              case FirstObjectKey =>
+                states = ObjectValue :: rest
+                Stream.empty
+              case ObjectKey =>
+                states = ObjectValue :: rest
+                sep
+              case ObjectValue =>
+                states = ObjectKey :: rest
+                Stream.empty
+              case FirstArrayValue =>
+                states = ArrayValue :: rest
+                Stream.empty
+              case ArrayValue =>
+                states = ArrayValue :: rest
+                sep
+            }
+        }
+
+      private def closeObject(): Stream[Pure, DocEvent] =
+        states match {
+          case Nil => endObject
+          case state :: rest =>
+            states = rest
+            (state: @switch) match {
+              case FirstObjectKey => endObject
+              case ObjectKey      => endObject
+            }
+        }
+
+      private def closeArray(): Stream[Pure, DocEvent] =
+        states match {
+          case Nil => endArray
+          case state :: rest =>
+            states = rest
+            (state: @switch) match {
+              case FirstArrayValue => endArray
+              case ArrayValue      => endArray
+            }
+        }
+
+      override def doc(token: Token): Stream[Pure, DocEvent] =
+        token match {
+          case StartObject =>
+            val res = separator() ++ startObject
+            states = FirstObjectKey :: states
+            res
+          case EndObject =>
+            closeObject()
+          case StartArray =>
+            val res = separator() ++ startArray
+            states = FirstArrayValue :: states
+            res
+          case EndArray =>
+            closeArray()
+          case Key(value) =>
+            val rendered = new StringBuilder
+            rendered.append('"')
+            renderString(value, 0, rendered)
+            rendered.append("\":")
+            separator() ++ Stream.emit(DocEvent.Text(rendered.result()))
+          case NullValue =>
+            separator() ++ nullValue
+          case TrueValue =>
+            separator() ++ trueValue
+          case FalseValue =>
+            separator() ++ falseValue
+          case NumberValue(value) =>
+            separator() ++ Stream.emit(DocEvent.Text(value))
+          case StringValue(value) =>
+            val rendered = new StringBuilder
+            rendered.append('"')
+            renderString(value, 0, rendered)
+            rendered.append('"')
+            separator() ++ Stream.emit(DocEvent.Text(rendered.result()))
+        }
+    }
+
   }
 
 }

--- a/json/src/main/scala/fs2/data/json/tokens.scala
+++ b/json/src/main/scala/fs2/data/json/tokens.scala
@@ -71,7 +71,7 @@ object Token {
     }
   }
 
-  private final val hex = "0123456789abcdef"
+  private final val hex = "0123456789abcdef".toArray
 
   @tailrec
   def renderString(s: String, idx: Int, builder: StringBuilder): Unit =

--- a/json/src/test/scala/fs2/data/json/RenderSpec.scala
+++ b/json/src/test/scala/fs2/data/json/RenderSpec.scala
@@ -16,10 +16,7 @@
 
 package fs2.data.json
 
-import internals._
-
 import fs2._
-
 import weaver._
 
 object RenderSpec extends SimpleIOSuite {
@@ -30,7 +27,7 @@ object RenderSpec extends SimpleIOSuite {
 
     val toks = input.through(tokens[Fallible, Char])
 
-    val roundtrip = toks.through(render.compact).flatMap(Stream.emits(_)).through(tokens)
+    val roundtrip = toks.through(render.compact).through(tokens)
 
     expect(toks.compile.toList == roundtrip.compile.toList)
 
@@ -42,20 +39,72 @@ object RenderSpec extends SimpleIOSuite {
 
     val toks = input.through(tokens[Fallible, Char])
 
-    val roundtrip = toks.through(render.pretty()).flatMap(Stream.emits(_)).through(tokens)
+    val roundtrip = toks.through(render.prettyPrint()).through(tokens)
 
     expect(toks.compile.toList == roundtrip.compile.toList)
 
   }
 
   pureTest("a Renderer should properly escape what needs to be escaped") {
-    val renderer = new Renderer(true, true, "")
+    val input = Stream.emit(Token.StringValue("some\ncharacters must\\be\"escaped\" like ß")).covaryOutput[Token]
 
-    renderer += Chunk.singleton(Token.StringValue("some\ncharacters must\\be\"escaped\" like ß"))
+    expect.same("\"some\\ncharacters must\\\\be\\\"escaped\\\" like \\u00df\"",
+                input.through(render.prettyPrint()).compile.string)
 
-    val res = renderer.result
+  }
 
-    expect(res == "\"some\\ncharacters must\\\\be\\\"escaped\\\" like \\u00df\"")
+  pureTest("An object should be properly pretty renderer with line width of 10") {
+    val input = Stream.emits("""{"field1": "test", "field2": [23, [true, null]]}""")
+
+    expect.same(
+      Right("""{
+              |  "field1": "test",
+              |  "field2": [
+              |    23,
+              |    [
+              |      true,
+              |      null
+              |    ]
+              |  ]
+              |}""".stripMargin),
+      input.through(tokens[Fallible, Char]).through(fs2.data.text.render.pretty(width = 10, indent = 2)).compile.string
+    )
+
+  }
+
+  pureTest("An object should be properly pretty renderer with line width of 32") {
+    val input = Stream.emits("""{"field1": "test", "field2": [23, [true, null]]}""")
+
+    expect.same(
+      Right("""{
+              |  "field1": "test",
+              |  "field2": [23, [true, null]]
+              |}""".stripMargin),
+      input.through(tokens[Fallible, Char]).through(fs2.data.text.render.pretty(width = 32, indent = 2)).compile.string
+    )
+
+  }
+
+  pureTest("An object should be properly pretty renderer with line width of 80") {
+    val input = Stream.emits("""{
+                               |  "field1": "test",
+                               |  "field2": [23, [true, null]]}""".stripMargin)
+
+    expect.same(
+      Right("""{"field1": "test", "field2": [23, [true, null]]}"""),
+      input.through(tokens[Fallible, Char]).through(fs2.data.text.render.pretty(width = 80, indent = 2)).compile.string
+    )
+  }
+
+  pureTest("An object should be properly pretty renderer with line width of 80") {
+    val input = Stream.emits("""{
+                               |  "field1": "test",
+                               |  "field2": [23, [true, null]]}""".stripMargin)
+
+    expect.same(
+      Right("""{"field1": "test", "field2": [23, [true, null]]}"""),
+      input.through(tokens[Fallible, Char]).through(fs2.data.text.render.pretty(width = 80, indent = 2)).compile.string
+    )
 
   }
 

--- a/site/cookbooks/jq.md
+++ b/site/cookbooks/jq.md
@@ -15,7 +15,7 @@ The _Reading_ and _Writing_ steps are not specific to `fs2-data` but rely on pur
 
  - The `tokens` pipe to parse the input stream into JSON @:api(fs2.data.json.Token)s (see [the documentation][json-doc] for more details).
  - The @:api(fs2.data.json.jq.Compiler) class to compile a query into a pipe (see [the documentation][jq-doc] for more details).
- - The `render.pretty` pipe to render the query result into a pretty-printed JSON string (see [the documentation][render-doc] for more details).
+ - The `render.prettyPrint` pipe to render the query result into a pretty-printed JSON string (see [the documentation][render-doc] for more details).
 
 In general the _Transforming_ step can use whatever operator fits your purpose, from `fs2` or any other `fs2`-based library. But in our case the only transformation will be performed by the query.
 
@@ -55,7 +55,7 @@ import fs2.data.json
 Files[IO]
   .readUtf8(Path("site/cookbooks/data/json/sample.json"))
   .through(json.tokens) // parsing JSON input
-  .through(json.render.pretty()) // pretty printing JSON stream
+  .through(json.render.prettyPrint()) // pretty printing JSON stream
   .through(utf8.encode[IO])
   .through(stdout)
   .compile
@@ -95,7 +95,7 @@ Files[IO]
   .readUtf8(Path("site/cookbooks/data/json/sample.json"))
   .through(json.tokens)
   .through(queryPipe) // the transformation using the query pipe
-  .through(json.render.pretty())
+  .through(json.render.prettyPrint())
   .through(utf8.encode[IO])
   .through(stdout)
   .compile

--- a/site/documentation/json/index.md
+++ b/site/documentation/json/index.md
@@ -128,17 +128,17 @@ stream
   .drain
 ```
 
-There exists also a `pretty()` renderer, that indents inner elements by the given indent string.
+There exists also a `prettyPrint()` renderer, that indents inner elements by the given indent size (in spaces) and for a given page width.
 
-If you are interested in the String rendering as a value, the library also provides `Collector`s:
+If you are interested in the String rendering as a value, you can use the `string` `Collector`:
 
 ```scala mdoc
-stream.compile.to(collector.compact)
+stream.through(render.compact).compile.string
 
 // default indentation is 2 spaces
-stream.compile.to(collector.pretty())
-// if you are more into tabs (or any other indentation size) you can change the indentation string
-stream.compile.to(collector.pretty("\t"))
+stream.through(render.prettyPrint(width = 10)).compile.string
+// if you are more into 4 spaces (or any other indentation size) you can change the indentation size
+stream.through(render.prettyPrint(indent = 4, width = 10)).compile.string
 ```
 
 ## Generating JSON streams

--- a/text/shared/src/main/scala/fs2/data/text/render/DocEvent.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/DocEvent.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.text.render
+
+sealed trait DocEvent
+
+object DocEvent {
+
+  /** Renders the text _as is_. */
+  case class Text(text: String) extends DocEvent
+
+  /** Adds a new line and indent, or a space if undone by a group */
+  case object Line extends DocEvent
+
+  /** Adds a new line and indent, or a empty if undone by a group */
+  case object LineBreak extends DocEvent
+
+  /** Begins a new group */
+  case object GroupBegin extends DocEvent
+
+  /** Ends a group */
+  case object GroupEnd extends DocEvent
+
+  /** Begins a new indent, incrementing the current indentation level */
+  case object IndentBegin extends DocEvent
+
+  /** Ends an indent , decrementing the current indentation level */
+  case object IndentEnd extends DocEvent
+
+  /** Begins a new alignment, setting the current indentation level to the current column */
+  case object AlignBegin extends DocEvent
+
+  /** Ends an alignment, setting the current indentation level back to what it was before this alignment */
+  case object AlignEnd extends DocEvent
+}

--- a/text/shared/src/main/scala/fs2/data/text/render/RenderException.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/RenderException.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.text.render
+
+final case class RenderException(msg: String) extends Exception(msg)

--- a/text/shared/src/main/scala/fs2/data/text/render/Renderable.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/Renderable.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.text.render
+
+/** Typeclass indicating how to render a given event type. */
+trait Renderable[Event] {
+
+  /** Creates a new instance of a renderer.
+    * This allows for renderer with mutable state.
+    * If the renderer has no state, it can return the same instance every time.
+    */
+  def newRenderer(): Renderer[Event]
+
+}

--- a/text/shared/src/main/scala/fs2/data/text/render/Renderer.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/Renderer.scala
@@ -16,9 +16,29 @@
 
 package fs2.data.text.render
 
-import fs2.{Stream, Pure}
+import fs2.{Chunk, Pure, Stream}
 
 trait Renderer[Event] {
+
+  /**
+    * Splits words in the given text into a stream of document events.
+    * This is a utility method, when you want to reformat a text using
+    * the pretty printer. The pretty printing algorithm assumes that each
+    * `DocEvent.Text` is an atomic value, so if it contains new lines it
+    * can break the computations.
+    *
+    * Between 2 words, it adds a `DocEvent.Line` event. Empty lines are not
+    * Generated.
+    *
+    * @param text The text to split
+    * @param wordBoundary The regular expression on which to split words
+    */
+  def words(text: String, wordBoundary: String = raw"\s+"): Stream[Pure, DocEvent] =
+    Stream
+      .chunk(Chunk.array(text.split(wordBoundary)))
+      .filter(_.nonEmpty)
+      .map(DocEvent.Text(_))
+      .intersperse(DocEvent.Line)
 
   /** Transforms the event into a stream of document events.
     * The stream may be partial (e.g. opening a group when the event describes a new tree node).

--- a/text/shared/src/main/scala/fs2/data/text/render/Renderer.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/Renderer.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.text.render
+
+import fs2.{Stream, Pure}
+
+trait Renderer[Event] {
+
+  /** Transforms the event into a stream of document events.
+    * The stream may be partial (e.g. opening a group when the event describes a new tree node).
+    */
+  def doc(evt: Event): Stream[Pure, DocEvent]
+
+}

--- a/text/shared/src/main/scala/fs2/data/text/render/internal/Annotated.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/internal/Annotated.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.text.render.internal
+
+private sealed trait Annotated
+private object Annotated {
+  case class Text(text: String, hp: Int) extends Annotated
+  case class Line(hp: Int) extends Annotated
+  case class LineBreak(hp: Int) extends Annotated
+  case class GroupBegin(hpl: Position) extends Annotated
+  case class GroupEnd(hp: Int) extends Annotated
+  case class IndentBegin(hp: Int) extends Annotated
+  case class IndentEnd(hp: Int) extends Annotated
+  case class AlignBegin(hp: Int) extends Annotated
+  case class AlignEnd(hp: Int) extends Annotated
+}

--- a/text/shared/src/main/scala/fs2/data/text/render/internal/Position.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/internal/Position.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.text.render.internal
+
+private sealed trait Position
+private object Position {
+  case object TooFar extends Position
+  case class Small(pos: Int) extends Position
+}

--- a/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
@@ -19,11 +19,9 @@ package internal
 
 import cats.collections.Dequeue
 import cats.data.{Chain, NonEmptyList}
-import fs2.{Chunk, Pipe, Pull, RaiseThrowable, Stream}
+import fs2.{Chunk, Pipe, Pull, Stream}
 
-private[render] class StreamPrinter[F[_], Event](width: Int, indentSize: Int)(implicit
-    F: RaiseThrowable[F],
-    render: Renderable[Event])
+private[render] class StreamPrinter[F[_], Event](width: Int, indentSize: Int)(implicit render: Renderable[Event])
     extends Pipe[F, Event, String] {
 
   private val emptyGroups = (0, Dequeue.empty[(Int, Chain[Annotated])])
@@ -74,12 +72,7 @@ private[render] class StreamPrinter[F[_], Event](width: Int, indentSize: Int)(im
     if (idx >= chunk.size) {
       rest.pull.uncons.flatMap {
         case Some((hd, tl)) => annotate(hd, 0, tl, pos, aligns, hpl, groups)
-        case None =>
-          if (!groups.isEmpty) {
-            Pull.raiseError(RenderException("Document stream malformed (unclosed group)"))
-          } else {
-            Pull.done
-          }
+        case None           => Pull.done
       }
     } else {
       val evt = chunk(idx)

--- a/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.text.render
+package internal
+
+import cats.collections.Dequeue
+import cats.data.{Chain, NonEmptyList}
+import fs2.{Chunk, Pipe, Pull, RaiseThrowable, Stream}
+
+private[render] class StreamPrinter[F[_], Event](width: Int, indentSize: Int)(implicit
+    F: RaiseThrowable[F],
+    render: Renderable[Event])
+    extends Pipe[F, Event, String] {
+
+  private val emptyGroups = (0, Dequeue.empty[(Int, Chain[Annotated])])
+
+  private def push(groups: Dequeue[(Int, Chain[Annotated])], evt: Annotated): Dequeue[(Int, Chain[Annotated])] =
+    groups.unsnoc match {
+      case Some(((ghpl, group), groups)) => groups.snoc((ghpl, group.append(evt)))
+      case None                          => Dequeue.empty // should never happen
+    }
+
+  private def pop(hpl: Int,
+                  groups: Dequeue[(Int, Chain[Annotated])],
+                  buffer: Chain[Annotated]): Pull[F, Annotated, (Int, Dequeue[(Int, Chain[Annotated])])] =
+    groups.unsnoc match {
+      case Some(((ghpl, group), groups)) =>
+        Pull.pure((hpl, groups.snoc((ghpl, group.concat(buffer)))))
+      case None =>
+        Pull.output(Chunk.chain(buffer)).as(emptyGroups)
+    }
+
+  private def check(hpl: Int,
+                    groups: Dequeue[(Int, Chain[Annotated])],
+                    ghpl: Int): Pull[F, Annotated, (Int, Dequeue[(Int, Chain[Annotated])])] =
+    if (ghpl <= hpl && groups.size <= width) {
+      // groups still fits
+      Pull.pure((hpl, groups))
+    } else {
+      // group does not fit, uncons first buffer
+      groups.uncons match {
+        case Some(((_, buffer), groups)) =>
+          Pull.output(Chunk.chain(buffer.prepend(Annotated.GroupBegin(Position.TooFar)))) >> (groups.uncons match {
+            case Some(((hpl, _), _)) => check(hpl, groups, ghpl) // check inner groups recursively
+            case None                => Pull.pure(emptyGroups)
+          })
+        case None =>
+          Pull.pure(emptyGroups) // should never happen
+
+      }
+    }
+
+  private def annotate(chunk: Chunk[DocEvent],
+                       idx: Int,
+                       rest: Stream[F, DocEvent],
+                       pos: Int,
+                       aligns: NonEmptyList[Int],
+                       hpl: Int,
+                       groups: Dequeue[(Int, Chain[Annotated])]): Pull[F, Annotated, Unit] =
+    if (idx >= chunk.size) {
+      rest.pull.uncons.flatMap {
+        case Some((hd, tl)) => annotate(hd, 0, tl, pos, aligns, hpl, groups)
+        case None =>
+          if (!groups.isEmpty) {
+            Pull.raiseError(RenderException("Document stream malformed (unclosed group)"))
+          } else {
+            Pull.done
+          }
+      }
+    } else {
+      val evt = chunk(idx)
+      evt match {
+        case DocEvent.Text(text) =>
+          val size = text.size
+          val pos1 = pos + size
+          if (groups.isEmpty) {
+            // no open group we can emit immediately
+            Pull.output1(Annotated.Text(text, pos1)) >> annotate(chunk, idx + 1, rest, pos1, aligns, hpl, groups)
+          } else {
+            // there is an open group, append the event to the current group
+            check(hpl, push(groups, Annotated.Text(text, pos1)), pos1).flatMap { case (hpl, groups) =>
+              annotate(chunk, idx + 1, rest, pos1, aligns, hpl, groups)
+            }
+          }
+
+        case DocEvent.Line =>
+          if (groups.isEmpty) {
+            // no open group we can emit immediately a new line
+            Pull.output1(Annotated.Line(pos + 1)) >> annotate(chunk, idx + 1, rest, pos + 1, aligns, hpl, groups)
+          } else {
+            // there is an open group, append the event to the current group
+            check(hpl, push(groups, Annotated.Line(pos + 1)), pos + 1).flatMap { case (hpl, groups) =>
+              annotate(chunk, idx + 1, rest, pos + 1, aligns, hpl, groups)
+            }
+          }
+
+        case DocEvent.LineBreak =>
+          if (groups.isEmpty) {
+            // no open group we can emit immediately a new line
+            Pull.output1(Annotated.LineBreak(pos)) >> annotate(chunk, idx + 1, rest, pos, aligns, hpl, groups)
+          } else {
+            // there is an open group, append the event to the current group
+            check(hpl, push(groups, Annotated.LineBreak(pos)), pos).flatMap { case (hpl, groups) =>
+              annotate(chunk, idx + 1, rest, pos, aligns, hpl, groups)
+            }
+          }
+
+        case DocEvent.GroupBegin =>
+          val hpl1 = pos + width + aligns.head
+          if (groups.isEmpty)
+            // this is the top-level group, turn on the buffer mechanism
+            annotate(chunk, idx + 1, rest, pos, aligns, hpl1, groups.snoc((hpl1, Chain.empty)))
+          else
+            // starting a new group, puts a new empty buffer in the group dequeue, and check for overflow
+            check(hpl, groups.snoc((hpl1, Chain.empty)), pos).flatMap { case (hpl, groups) =>
+              annotate(chunk, idx + 1, rest, pos, aligns, hpl, groups)
+            }
+
+        case DocEvent.GroupEnd =>
+          groups.unsnoc match {
+            case None =>
+              // closing unknown group, just ignore it
+              annotate(chunk, idx + 1, rest, pos, aligns, hpl, groups)
+
+            case Some(((_, group), groups)) =>
+              // closing a group, pop it from the buffer dequeue, and continue
+              pop(hpl, groups, group.prepend(Annotated.GroupBegin(Position.Small(pos))).append(Annotated.GroupEnd(pos)))
+                .flatMap { case (hpl, groups) =>
+                  annotate(chunk, idx + 1, rest, pos, aligns, hpl, groups)
+                }
+
+          }
+
+        case DocEvent.IndentBegin =>
+          // increment the current indentation level
+          if (groups.isEmpty) {
+            // no open group we can emit immediately a new line
+            Pull.output1(Annotated.IndentBegin(pos)) >> annotate(chunk,
+                                                                 idx + 1,
+                                                                 rest,
+                                                                 pos,
+                                                                 NonEmptyList(aligns.head + 1, aligns.tail),
+                                                                 hpl,
+                                                                 groups)
+          } else {
+            // there is an open group, append the event to the current group
+            check(hpl, push(groups, Annotated.IndentBegin(pos)), pos).flatMap { case (hpl, groups) =>
+              annotate(chunk, idx + 1, rest, pos, NonEmptyList(aligns.head + 1, aligns.tail), hpl, groups)
+            }
+          }
+
+        case DocEvent.IndentEnd =>
+          // decrement the current indentation level
+          if (groups.isEmpty) {
+            // no open group we can emit immediately a new line
+            Pull.output1(Annotated.IndentEnd(pos)) >> annotate(chunk,
+                                                               idx + 1,
+                                                               rest,
+                                                               pos,
+                                                               NonEmptyList(aligns.head - 1, aligns.tail),
+                                                               hpl,
+                                                               groups)
+          } else {
+            // there is an open group, append the event to the current group
+            check(hpl, push(groups, Annotated.IndentEnd(pos)), pos).flatMap { case (hpl, groups) =>
+              annotate(chunk, idx + 1, rest, pos, NonEmptyList(aligns.head - 1, aligns.tail), hpl, groups)
+            }
+          }
+
+        case DocEvent.AlignBegin =>
+          // push new indentation level
+          if (groups.isEmpty) {
+            // no open group we can emit immediately a new line
+            Pull.output1(Annotated.AlignBegin(pos)) >> annotate(chunk, idx + 1, rest, pos, pos :: aligns, hpl, groups)
+          } else {
+            // there is an open group, append the event to the current group
+            check(hpl, push(groups, Annotated.AlignBegin(pos)), pos).flatMap { case (hpl, groups) =>
+              annotate(chunk, idx + 1, rest, pos, pos :: aligns, hpl, groups)
+            }
+          }
+
+        case DocEvent.AlignEnd =>
+          // restore to previous indentation level
+          val aligns1 =
+            aligns match {
+              case NonEmptyList(_, i :: is) => NonEmptyList(i, is)
+              case NonEmptyList(_, Nil)     => NonEmptyList.one(0)
+            }
+          if (groups.isEmpty) {
+            // no open group we can emit immediately a new line
+            Pull.output1(Annotated.AlignEnd(pos)) >> annotate(chunk, idx + 1, rest, pos, aligns1, hpl, groups)
+          } else {
+            // there is an open group, append the event to the current group
+            check(hpl, push(groups, Annotated.AlignEnd(pos)), pos).flatMap { case (hpl, groups) =>
+              annotate(chunk, idx + 1, rest, pos, aligns1, hpl, groups)
+            }
+          }
+      }
+    }
+
+  def apply(events: Stream[F, Event]): Stream[F, String] =
+    annotate(
+      Chunk.empty,
+      0,
+      Stream.suspend(Stream.emit(render.newRenderer())).flatMap(renderer => events.flatMap(renderer.doc(_))),
+      0,
+      NonEmptyList.one(0),
+      0,
+      Dequeue.empty
+    ).stream
+      .mapAccumulate((0, width, NonEmptyList.one(""))) { case (acc @ (fit, hpl, lines), evt) =>
+        evt match {
+          case Annotated.Text(text, _)                           => (acc, Some(text))
+          case Annotated.Line(pos) if fit == 0                   => ((fit, pos + width, lines), Some("\n" + lines.head))
+          case Annotated.Line(_)                                 => (acc, Some(" "))
+          case Annotated.LineBreak(pos) if fit == 0              => ((fit, pos + width, lines), Some("\n" + lines.head))
+          case Annotated.LineBreak(_)                            => (acc, None)
+          case Annotated.GroupBegin(Position.TooFar) if fit == 0 => ((0, hpl, lines), None)
+          case Annotated.GroupBegin(Position.Small(pos)) if fit == 0 => ((if (pos <= hpl) 1 else 0, hpl, lines), None)
+          case Annotated.GroupBegin(_)                               => ((fit + 1, hpl, lines), None)
+          case Annotated.GroupEnd(_) if fit == 0                     => (acc, None)
+          case Annotated.GroupEnd(_)                                 => ((fit - 1, hpl, lines), None)
+          case Annotated.IndentBegin(_) =>
+            ((fit, hpl, NonEmptyList(lines.head + (" " * indentSize), lines.tail)), None)
+          case Annotated.IndentEnd(_) =>
+            ((fit, hpl, NonEmptyList(lines.head.drop(indentSize), lines.tail)), None)
+          case Annotated.AlignBegin(pos) =>
+            ((fit, hpl, (" " * pos) :: lines), None)
+          case Annotated.AlignEnd(_) =>
+            ((fit, hpl, NonEmptyList.fromList(lines.tail).getOrElse(NonEmptyList.one(""))), None)
+        }
+
+      }
+      .map(_._2)
+      .unNone
+}

--- a/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
@@ -236,7 +236,6 @@ private[render] class StreamPrinter[F[_], Event](width: Int, indentSize: Int)(im
       0,
       Dequeue.empty
     ).stream
-      .debug()
       .mapAccumulate((0, width, NonEmptyList.one(""), 0)) { case (acc @ (fit, hpl, lines, col), evt) =>
         evt match {
           case Annotated.Text(text, _)         => ((fit, hpl, lines, col + text.size), Some(text))

--- a/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
@@ -46,9 +46,8 @@ private[render] class StreamPrinter[F[_], Event](width: Int, indentSize: Int)(im
                     indent: Int,
                     groups: Dequeue[(Int, Int, Chain[Annotated])],
                     ghpl: Int): Pull[F, Annotated, (Int, Int, Dequeue[(Int, Int, Chain[Annotated])])] =
-    if (ghpl <= hpl - indent && groups.size <= width - indent) {
+    if (ghpl <= hpl - (indent * indentSize) && groups.size <= width - (indent * indentSize)) {
       // groups still fits
-      println(s"ghpl: $ghpl, hpl - indent: ${hpl - indent}, groups: ${groups.size}, width - indent: ${width - indent}")
       Pull.pure((hpl, indent, groups))
     } else {
       // group does not fit, uncons first buffer
@@ -160,7 +159,7 @@ private[render] class StreamPrinter[F[_], Event](width: Int, indentSize: Int)(im
                                                                  pos,
                                                                  NonEmptyList(aligns.head + 1, aligns.tail),
                                                                  hpl,
-                                                                 indent+1,
+                                                                 indent + 1,
                                                                  groups)
           } else {
             // there is an open group, append the event to the current group

--- a/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
@@ -232,7 +232,7 @@ private[render] class StreamPrinter[F[_], Event](width: Int, indentSize: Int)(im
           case Annotated.IndentEnd(_) =>
             ((fit, hpl, NonEmptyList(lines.head.drop(indentSize), lines.tail)), None)
           case Annotated.AlignBegin(pos) =>
-            ((fit, hpl, (" " * pos) :: lines), None)
+            ((fit, hpl, (" " * (pos - hpl)) :: lines), None)
           case Annotated.AlignEnd(_) =>
             ((fit, hpl, NonEmptyList.fromList(lines.tail).getOrElse(NonEmptyList.one(""))), None)
         }

--- a/text/shared/src/main/scala/fs2/data/text/render/package.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.text
+
+import fs2.data.text.render.internal.StreamPrinter
+import fs2.{Pipe, RaiseThrowable}
+
+package object render {
+
+  def pretty[F[_], Event](width: Int = 100, indent: Int = 2)(implicit
+      F: RaiseThrowable[F],
+      render: Renderable[Event]): Pipe[F, Event, String] =
+    new StreamPrinter[F, Event](width, indent)
+
+}

--- a/text/shared/src/main/scala/fs2/data/text/render/package.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/package.scala
@@ -16,13 +16,12 @@
 
 package fs2.data.text
 
+import fs2.Pipe
 import fs2.data.text.render.internal.StreamPrinter
-import fs2.{Pipe, RaiseThrowable}
 
 package object render {
 
   def pretty[F[_], Event](width: Int = 100, indent: Int = 2)(implicit
-      F: RaiseThrowable[F],
       render: Renderable[Event]): Pipe[F, Event, String] =
     new StreamPrinter[F, Event](width, indent)
 

--- a/xml/src/main/scala/fs2/data/xml/XmlEvent.scala
+++ b/xml/src/main/scala/fs2/data/xml/XmlEvent.scala
@@ -141,16 +141,19 @@ object XmlEvent {
               DocEvent.GroupBegin :: DocEvent.Text(show"<$name ") :: DocEvent.AlignBegin :: Nil) ++ Stream
               .emits(as)
               .map(a => DocEvent.Text(a.show))
-              .intersperse(DocEvent.Line) ++ Stream.emits(DocEvent.AlignEnd :: DocEvent.Text(if (isEmpty) " />"
-            else ">") :: DocEvent.GroupEnd :: (if (isEmpty) Nil
-                                               else DocEvent.IndentBegin :: DocEvent.GroupBegin :: Nil))
+              .intersperse(DocEvent.Line) ++ Stream.emits(
+              DocEvent.AlignEnd :: DocEvent.Text(if (isEmpty) " />"
+              else ">") :: DocEvent.GroupEnd :: (if (isEmpty) Nil
+                                                 else DocEvent.IndentBegin :: DocEvent.GroupBegin :: Nil))
           case XmlString(s, false) =>
             prefix(TEXT) ++ words(s)
           case texty: XmlTexty =>
             prefix(TEXT) ++ Stream.emit(DocEvent.Text(texty.render))
-          case XmlPI(target, content) =>
+          case XmlPI(_, _) =>
+            // TODO: add support for proper PI parsing so that we can render it properly
             Stream.empty
-          case XmlDoctype(name, docname, systemid) =>
+          case XmlDoctype(_, _, _) =>
+            // TODO: add support for proper Doctype parsing so that we can render it properly
             Stream.empty
           case EndTag(name) =>
             val res =

--- a/xml/src/main/scala/fs2/data/xml/package.scala
+++ b/xml/src/main/scala/fs2/data/xml/package.scala
@@ -22,6 +22,7 @@ import xml.internals._
 
 import cats._
 import cats.syntax.all._
+import fs2.data.text.render.Renderable
 
 package object xml {
 
@@ -103,15 +104,10 @@ package object xml {
       *
       * This pipe can be used when whitespace characters are not relevant to the application
       * and to make it more readable to human beings.
-      *
-      * @param collapseEmpty Whether empty tags are collapsed in a single self closing tag
-      * @param indent THe indentation string
-      * @param attributeThreshold Number of attributes above which each attribute is rendered on a new line
       */
-    def pretty[F[_]](collapseEmpty: Boolean = true,
-                     indent: String = "  ",
-                     attributeThreshold: Int = 3): Pipe[F, XmlEvent, String] =
-      Renderer.pipe(true, collapseEmpty, indent, attributeThreshold)
+    def prettyPrint[F[_]](width: Int = 80, indent: Int = 2)(implicit
+        renderable: Renderable[XmlEvent]): Pipe[F, XmlEvent, String] =
+      _.through(fs2.data.text.render.pretty(width = width, indent = indent))
 
   }
 

--- a/xml/src/test/scala/fs2/data/xml/XmlRenderTest.scala
+++ b/xml/src/test/scala/fs2/data/xml/XmlRenderTest.scala
@@ -17,151 +17,168 @@
 package fs2.data.xml
 
 import cats.effect.IO
-import cats.syntax.all._
 import weaver._
 
 object XmlRenderTest extends SimpleIOSuite {
 
   test("renders xml with self-closing tags") {
-    val result =
-      xml"""<?xml version="1.0" encoding="utf-8"?><doc><no-content/></doc>""".through(render.raw()).compile.string
-    result.liftTo[IO].map { result =>
-      expect.eql("""<?xml version="1.0" encoding="utf-8"?><doc><no-content/></doc>""", result)
-    }
+    xml"""<?xml version="1.0" encoding="utf-8"?><doc><no-content/></doc>"""
+      .lift[IO]
+      .through(render.raw())
+      .compile
+      .string
+      .map { result =>
+        expect.eql("""<?xml version="1.0" encoding="utf-8"?><doc><no-content/></doc>""", result)
+      }
   }
 
   test("renders xml with self-closing tags prettily") {
-    val result =
-      xml"""<?xml version="1.0" encoding="utf-8"?><doc><no-content/></doc>"""
-        .through(render.prettyPrint(width = 0))
-        .compile
-        .string
-    result.liftTo[IO].map { result =>
-      expect.eql(
-        """<?xml version="1.0" encoding="utf-8"?>
+    xml"""<?xml version="1.0" encoding="utf-8"?><doc><no-content/></doc>"""
+      .lift[IO]
+      .through(render.prettyPrint(width = 0))
+      .compile
+      .string
+      .map { result =>
+        expect.eql(
+          """<?xml version="1.0"
+          |      encoding="utf-8"?>
           |<doc>
           |  <no-content />
           |</doc>""".stripMargin,
-        result
-      )
-    }
+          result
+        )
+      }
   }
 
   test("renders xml without self-closing tags if disabled") {
-    val result =
-      xml"""<?xml version="1.0" encoding="utf-8"?><doc><no-content/></doc>""".through(render.raw(false)).compile.string
-    result.liftTo[IO].map { result =>
-      expect.eql("""<?xml version="1.0" encoding="utf-8"?><doc><no-content></no-content></doc>""", result)
-    }
+    xml"""<?xml version="1.0" encoding="utf-8"?><doc><no-content/></doc>"""
+      .lift[IO]
+      .through(render.raw(false))
+      .compile
+      .string
+      .map { result =>
+        expect.eql("""<?xml version="1.0" encoding="utf-8"?><doc><no-content></no-content></doc>""", result)
+      }
   }
 
   test("renders xml with attributes prettily if it fits on one line") {
-    val result =
-      xml"""<?xml version="1.0" encoding="utf-8"?><doc a1="value1" a2="value2"><no-content/></doc>"""
-        .through(render.prettyPrint(width = 30))
-        .compile
-        .string
-    result.liftTo[IO].map { result =>
-      expect.eql(
-        """<?xml version="1.0" encoding="utf-8"?>
+    xml"""<?xml version="1.0" encoding="utf-8"?><doc a1="value1" a2="value2"><no-content/></doc>"""
+      .lift[IO]
+      .through(render.prettyPrint(width = 40))
+      .compile
+      .string
+      .map { result =>
+        expect.eql(
+          """<?xml version="1.0" encoding="utf-8"?>
           |<doc a1="value1" a2="value2">
           |  <no-content />
           |</doc>""".stripMargin,
-        result
-      )
-    }
+          result
+        )
+      }
   }
 
   test("renders xml with attributes prettily if it doesn't fit on one line") {
-    val result =
-      xml"""<?xml version="1.0" encoding="utf-8"?><doc a1="value1" a2="value2" a3="value3" a4="value4"><no-content/></doc>"""
-        .through(render.prettyPrint(width = 0))
-        .compile
-        .string
-    result.liftTo[IO].flatTap(IO.println(_)).map { result =>
-      expect.eql(
-        """<?xml version="1.0" encoding="utf-8"?>
+    xml"""<?xml version="1.0" encoding="utf-8"?><doc a1="value1" a2="value2" a3="value3" a4="value4"><no-content/></doc>"""
+      .lift[IO]
+      .through(render.prettyPrint(width = 0))
+      .compile
+      .string
+      .map { result =>
+        expect.eql(
+          """<?xml version="1.0"
+          |      encoding="utf-8"?>
           |<doc a1="value1"
           |     a2="value2"
           |     a3="value3"
           |     a4="value4">
           |  <no-content />
           |</doc>""".stripMargin,
-        result
-      )
-    }
+          result
+        )
+      }
   }
 
   test("renders text prettily") {
-    val result =
-      xml"""<?xml version="1.0" encoding="utf-8"?><doc>This is a test.
-The text is not originally formatted.</doc>""".through(render.prettyPrint(width = 20)).compile.string
-    result.liftTo[IO].map { result =>
-      expect.eql(
-        """<?xml version="1.0" encoding="utf-8"?>
+    xml"""<?xml version="1.0" encoding="utf-8"?><doc>This is a test.
+The text is not originally formatted.</doc>"""
+      .lift[IO]
+      .through(render.prettyPrint(width = 20))
+      .compile
+      .string
+      .map { result =>
+        expect.eql(
+          """<?xml version="1.0"
+          |      encoding="utf-8"?>
           |<doc>
-          |  This is a test. The
-          |  text is not
-          |  originally
-          |  formatted.
+          |  This is a test. The text
+          |  is not originally formatted.
           |</doc>""".stripMargin,
-        result
-      )
-    }
+          result
+        )
+      }
   }
 
   test("renders text with entities prettily") {
-    val result =
-      xml"""<?xml version="1.0" encoding="utf-8"?><doc>This is a test.
+    xml"""<?xml version="1.0" encoding="utf-8"?><doc>This is a test.
 The text is not originally formatted but contains &amp; and
-&acute; as entities.</doc>""".through(render.prettyPrint(width = 30)).compile.string
-    result.liftTo[IO].map { result =>
-      expect.eql(
-        """<?xml version="1.0" encoding="utf-8"?>
+&acute; as entities.</doc>"""
+      .lift[IO]
+      .through(render.prettyPrint(width = 30))
+      .compile
+      .string
+      .map { result =>
+        expect.eql(
+          """<?xml version="1.0"
+          |      encoding="utf-8"?>
           |<doc>
-          |  This is a test. The text is
-          |  not originally formatted but
-          |  contains &amp; and &acute;
-          |  as entities.
+          |  This is a test. The text is not
+          |  originally formatted but contains
+          |  &amp; and &acute; as entities.
           |</doc>""".stripMargin,
-        result
-      )
-    }
+          result
+        )
+      }
   }
 
   test("renders CDATA as-is") {
-    val result =
-      xml"""<?xml version="1.0" encoding="utf-8"?><doc><![CDATA[This is a test.
-The text is not originally formatted.]]></doc>""".through(render.prettyPrint(width = 0)).compile.string
-    result.liftTo[IO].map { result =>
-      expect.eql(
-        """<?xml version="1.0" encoding="utf-8"?>
+    xml"""<?xml version="1.0" encoding="utf-8"?><doc><![CDATA[This is a test.
+The text is not originally formatted.]]></doc>"""
+      .lift[IO]
+      .through(render.prettyPrint(width = 0))
+      .compile
+      .string
+      .map { result =>
+        expect.eql(
+          """<?xml version="1.0"
+          |      encoding="utf-8"?>
           |<doc>
           |  <![CDATA[This is a test.
           |The text is not originally formatted.]]>
           |</doc>""".stripMargin,
-        result
-      )
-    }
+          result
+        )
+      }
   }
 
   test("renders comments prettily") {
-    val result =
-      rawxml"""<?xml version="1.0" encoding="utf-8"?><doc><!-- This is a comment. --></doc>"""
-        .through(render.prettyPrint(width = 0))
-        .compile
-        .string
-    result.liftTo[IO].map { result =>
-      expect.eql(
-        """<?xml version="1.0" encoding="utf-8"?>
+    rawxml"""<?xml version="1.0" encoding="utf-8"?><doc><!-- This is a comment. --></doc>"""
+      .lift[IO]
+      .through(render.prettyPrint(width = 20))
+      .compile
+      .string
+      .map { result =>
+        expect.eql(
+          """<?xml version="1.0"
+          |      encoding="utf-8"?>
           |<doc>
           |  <!--
           |  This is a comment.
           |  -->
           |</doc>""".stripMargin,
-        result
-      )
-    }
+          result
+        )
+      }
   }
 
 }


### PR DESCRIPTION
It is inspired by the paper [_Lazy v. Yield: Incremental, Linear Pretty-printing_](https://okmij.org/ftp/continuations/PPYield/yield-pp.pdf) by Oleg Kiselyov, Simon Peyton-Jones, and Amr Sabry.

It adds indentation and alignment features to be useful in the context of streaming tree structure pretty printing (XML, JSON, ...).

Any type that has an instance of `Renderable` can be printed.

The printer guarantees that the data is printed as early as possible and the it is correct up to the first malformed tree structure.