### PR TITLE
Pin scala 3 to 3.3.x branch

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,9 @@
 updatePullRequests = "always"
+
+updates.pin  = [
+  {
+    groupId = "org.scala-lang",
+    artifactId="scala3-library",
+    version = "3.3."
+  }
+]


### PR DESCRIPTION
Since this is a library, we stick to the LTS version.

Refers to #587 