### PR TITLE
Emit an error if row and header size mismatch

### DIFF
--- a/csv/shared/src/test/scala/fs2/data/csv/RowGeneratorTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/RowGeneratorTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.csv
+
+import cats.data.NonEmptyList
+import weaver.*
+
+object RowGeneratorTest extends SimpleIOSuite {
+
+  pureTest("Emit error on wrong row size (#621)") {
+    val input = List(
+      Row(NonEmptyList.of("a", "b", "c"), Some(1)),
+      Row(NonEmptyList.of("d", "e"), Some(2)),
+      Row(NonEmptyList.of("f", "g", "h", "i"), Some(3)),
+      Row(NonEmptyList.of("j", "k", "l"), Some(4))
+    )
+    val headers = NonEmptyList.of("first", "second", "third")
+
+    val result = fs2.Stream.emits(input).through(lowlevel.attemptWriteWithGivenHeaders(headers)).compile.toList
+
+    matches(result) {
+      case List(
+            Right(NonEmptyList("first", "second" :: "third" :: Nil)),
+            Right(NonEmptyList("a", "b" :: "c" :: Nil)),
+            Left(e1: HeaderSizeError),
+            Left(e2: HeaderSizeError),
+            Right(NonEmptyList("j", "k" :: "l" :: Nil))
+          ) =>
+        expect.all(e1.expectedColumns == 3,
+                   e1.actualColumns == 2,
+                   e1.line == Some(2L),
+                   e2.expectedColumns == 3,
+                   e2.actualColumns == 4,
+                   e2.line == Some(3L))
+    }
+  }
+}

--- a/site/documentation/csv/index.md
+++ b/site/documentation/csv/index.md
@@ -51,7 +51,7 @@ More high-level pipes are available for the following use cases:
 * `decodeGivenHeaders` for CSV parsing that requires headers, but they aren't present in the input
 * `decodeUsingHeaders` for CSV parsing that requires headers and they're present in the input
 * `encodeWithoutHeaders` for CSV encoding that works entirely without headers (Note: requires `RowEncoder` instead of `CsvRowEncoder`)
-* `encodeGivenHeaders` for CSV encoding that works without headers, but they should be added to the output
+* `encodeWithGivenHeaders` for CSV encoding that works without headers, but they should be added to the output
 * `encodeUsingFirstHeaders` for CSV encoding that works with headers. Uses the headers of the first row for the output.
 
 ### Dealing with erroneous files
@@ -219,7 +219,7 @@ testRows
   .string
 ```
 
-If you want to write headers, use `writeWithHeaders` or, in case you use `CsvRow`, `encodeRowWithFirstHeaders`. For writing non-String headers, you'll need to provide an instance of `WritableHeader`, a type class analog to `ParseableHeader`.
+If you want to write headers, use `writeWithGivenHeaders` or, in case you use `CsvRow`, `encodeRowWithFirstHeaders`. For writing non-String headers, you'll need to provide an instance of `WritableHeader`, a type class analog to `ParseableHeader`.
 
 ## The type classes: Decoders and Encoders
 


### PR DESCRIPTION
Fixes #621 

A new method is created and the old one is deprecated to keep binary compatibility.