### PR TITLE
Improve stream rendering performances

### DIFF
--- a/benchmarks/src/main/scala/fs2/data/benchmarks/PrinterBenchmarks.scala
+++ b/benchmarks/src/main/scala/fs2/data/benchmarks/PrinterBenchmarks.scala
@@ -1,0 +1,85 @@
+package fs2.data.benchmarks
+
+import cats.effect.SyncIO
+import cats.effect.IO
+import fs2.data.json.Token
+import fs2.data.json.circe.*
+import fs2.{Fallible, Stream}
+import io.circe.Json
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+import cats.effect.unsafe.implicits.global
+
+import java.util.concurrent.TimeUnit
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Array(Mode.AverageTime))
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 15, time = 5)
+@Measurement(iterations = 10, time = 5)
+class PrinterBenchmarks {
+
+  val intArrayStream =
+    Stream.emits(
+      Token.StartArray ::
+        (List
+          .range(0, 1000000)
+          .map(i => Token.NumberValue(i.toString())) :+ Token.EndArray))
+
+  val objectStream =
+    Stream.emits(
+      Token.StartObject ::
+        (List
+          .range(0, 1000000)
+          .flatMap(i => List(Token.Key(s"key:$i"), Token.NumberValue(i.toString()))) :+ Token.EndObject))
+
+  @Benchmark
+  def intArrayCompact(bh: Blackhole) =
+    bh.consume(
+      intArrayStream
+        .through(fs2.data.json.render.compact)
+        .compile
+        .drain)
+
+  @Benchmark
+  def objectCompact(bh: Blackhole) =
+    bh.consume(
+      objectStream
+        .through(fs2.data.json.render.compact)
+        .compile
+        .drain)
+
+  @Benchmark
+  def intArrayPretty(bh: Blackhole) =
+    bh.consume(
+      intArrayStream
+        .through(fs2.data.json.render.prettyPrint())
+        .compile
+        .drain)
+
+  @Benchmark
+  def objectPretty(bh: Blackhole) =
+    bh.consume(
+      objectStream
+        .through(fs2.data.json.render.prettyPrint())
+        .compile
+        .drain)
+
+  @Benchmark
+  def intArrayPrettyLegacy(bh: Blackhole) =
+    bh.consume(
+      intArrayStream
+        .through(fs2.data.json.render.pretty())
+        .compile
+        .drain)
+
+  @Benchmark
+  def objectPrettyLegacy(bh: Blackhole) =
+    bh.consume(
+      objectStream
+        .through(fs2.data.json.render.pretty())
+        .compile
+        .drain)
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,46 @@ lazy val text = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.data.text.CharLikeStringChunks.pullNext"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.data.text.CharLikeStringChunks.advance"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.data.text.CharLikeStringChunks.current"),
-      ProblemFilters.exclude[MissingClassProblem]("fs2.data.text.CharLikeStringChunks$StringContext")
+      ProblemFilters.exclude[MissingClassProblem]("fs2.data.text.CharLikeStringChunks$StringContext"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.data.text.render.internal.Annotated$AlignBegin"),
+      ProblemFilters.exclude[MissingTypesProblem]("fs2.data.text.render.internal.Annotated$AlignBegin$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#AlignBegin.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#AlignBegin.unapply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "fs2.data.text.render.internal.Annotated#AlignBegin.fromProduct"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.data.text.render.internal.Annotated$AlignEnd"),
+      ProblemFilters.exclude[MissingTypesProblem]("fs2.data.text.render.internal.Annotated$AlignEnd$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#AlignEnd.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#AlignEnd.unapply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "fs2.data.text.render.internal.Annotated#AlignEnd.fromProduct"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.data.text.render.internal.Annotated$GroupEnd"),
+      ProblemFilters.exclude[MissingTypesProblem]("fs2.data.text.render.internal.Annotated$GroupEnd$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#GroupEnd.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#GroupEnd.unapply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "fs2.data.text.render.internal.Annotated#GroupEnd.fromProduct"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.data.text.render.internal.Annotated$IndentBegin"),
+      ProblemFilters.exclude[MissingTypesProblem]("fs2.data.text.render.internal.Annotated$IndentBegin$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#IndentBegin.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#IndentBegin.unapply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "fs2.data.text.render.internal.Annotated#IndentBegin.fromProduct"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.data.text.render.internal.Annotated$IndentEnd"),
+      ProblemFilters.exclude[MissingTypesProblem]("fs2.data.text.render.internal.Annotated$IndentEnd$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#IndentEnd.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#IndentEnd.unapply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "fs2.data.text.render.internal.Annotated#IndentEnd.fromProduct"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#Line.hp"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#LineBreak.hp"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#Text.hp"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#Text.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#Text.copy$default$2"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#Text.this"),
+      ProblemFilters.exclude[MissingTypesProblem]("fs2.data.text.render.internal.Annotated$Text$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#Text.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.data.text.render.internal.Annotated#Text._2")
     )
   )
   .nativeSettings(

--- a/text/shared/src/main/scala/fs2/data/text/render/internal/Annotated.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/internal/Annotated.scala
@@ -18,13 +18,13 @@ package fs2.data.text.render.internal
 
 private sealed trait Annotated
 private object Annotated {
-  case class Text(text: String, hp: Int) extends Annotated
-  case class Line(hp: Int) extends Annotated
-  case class LineBreak(hp: Int) extends Annotated
+  case class Text(text: String) extends Annotated
+  case class Line(pos: Int) extends Annotated
+  case class LineBreak(pos: Int) extends Annotated
   case class GroupBegin(hpl: Position) extends Annotated
-  case class GroupEnd(hp: Int) extends Annotated
-  case class IndentBegin(hp: Int) extends Annotated
-  case class IndentEnd(hp: Int) extends Annotated
-  case class AlignBegin(hp: Int) extends Annotated
-  case class AlignEnd(hp: Int) extends Annotated
+  case object GroupEnd extends Annotated
+  case object IndentBegin extends Annotated
+  case object IndentEnd extends Annotated
+  case object AlignBegin extends Annotated
+  case object AlignEnd extends Annotated
 }

--- a/text/shared/src/main/scala/fs2/data/text/render/internal/NonEmptyIntList.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/internal/NonEmptyIntList.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.text.render.internal
+
+private sealed trait NonEmptyIntList {
+  def head: Int
+  def ::(i: Int): NonEmptyIntList =
+    More(i, this)
+  def incHead: NonEmptyIntList
+  def decHead: NonEmptyIntList
+  def pop: NonEmptyIntList
+}
+private final case class One(head: Int) extends NonEmptyIntList {
+  override def incHead: NonEmptyIntList = One(head + 1)
+  override def decHead: NonEmptyIntList = One(head - 1)
+  override lazy val pop: NonEmptyIntList = One(0)
+}
+private final case class More(head: Int, tail: NonEmptyIntList) extends NonEmptyIntList {
+  override def incHead: NonEmptyIntList = More(head + 1, tail)
+  override def decHead: NonEmptyIntList = More(head - 1, tail)
+  override def pop: NonEmptyIntList = tail
+}

--- a/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
+++ b/text/shared/src/main/scala/fs2/data/text/render/internal/StreamPrinter.scala
@@ -220,7 +220,7 @@ private[render] class StreamPrinter[F[_], Event](width: Int, indentSize: Int)(im
   private def renderLine(pos: Int, ctx: RenderingContext, chunkAcc: StringBuilder): Unit = if (ctx.fit == 0) {
     ctx.hpl = pos + width
     ctx.col = ctx.lines.head.size
-    chunkAcc.append('\n').append(ctx.lines.head): Unit
+    val _ = chunkAcc.append('\n').append(ctx.lines.head)
   } else {
     ctx.col += 1
     chunkAcc.append(' ')
@@ -230,7 +230,7 @@ private[render] class StreamPrinter[F[_], Event](width: Int, indentSize: Int)(im
     if (ctx.fit == 0) {
       ctx.hpl = pos + width
       ctx.col = ctx.lines.head.size
-      chunkAcc.append('\n').append(ctx.lines.head): Unit
+      val _ = chunkAcc.append('\n').append(ctx.lines.head)
     }
 
   private def renderGroupBegin(pos: Position, ctx: RenderingContext): Unit =


### PR DESCRIPTION
This change addresses #634 in two ways:
 - A change to the generic pretty printer that allows to avoid:
   - Boxing of integers when computing the layout
   - Instantiating many tuples that are immediately discarded
   - Creating intermediate chunks by fusing the annotation and rendering phases
 - Re-introduce a direct compact rendering for JSON, that is way simpler than leveraging the generic printer with no groups

By doing so, the compact rendering should be back to the performance in 1.10 and the pretty case is improved a bit.

Here are some benchmark results with the compact rendering in 1.11.1 as the baseline. 1.11.2 represents the results with this change.

```mermaid
xychart-beta
  title "Rendering of int array"
  x-axis ["Pretty 1.10", "Pretty 1.11.1", "Pretty 1.11.2", "Compact 1.11.1", "Compact 1.11.2"]
  y-axis "Factor" 0 --> 1.2
  bar [0.02, 1.12, 0.71, 1, 0.004]
```

```mermaid
xychart-beta
  title "Rendering of int object"
  x-axis ["Pretty 1.10", "Pretty 1.11.1", "Pretty 1.11.2", "Compact 1.11.1", "Compact 1.11.2"]
  y-axis "Factor" 0 --> 1.2
  bar [0.01, 1.11, 0.85, 1, 0.01]
```