### PR TITLE
Add safer path operators and improve documentation

### DIFF
--- a/finite-state/shared/src/main/scala/fs2/data/pfsa/TreeQueryPipe.scala
+++ b/finite-state/shared/src/main/scala/fs2/data/pfsa/TreeQueryPipe.scala
@@ -138,6 +138,9 @@ private[data] abstract class TreeQueryPipe[F[_]: Concurrent, T, O <: T, Matcher,
   final def topmost(s: Stream[F, T]): Stream[F, T] =
     raw(Int.MaxValue, 0)(s).parJoinUnbounded
 
+  final def through(s: Stream[F, T], pipe: Pipe[F, T, Nothing], maxMatch: Int, maxNest: Int): Stream[F, Nothing] =
+    raw(maxMatch = maxMatch, maxNest = maxNest)(s).map(_.through(pipe)).parJoinUnbounded
+
   final def aggregate[U](s: Stream[F, T],
                          f: Stream[F, T] => F[U],
                          deterministic: Boolean,

--- a/json/src/test/scala/fs2/data/json/jsonpath/JsonPathSpec.scala
+++ b/json/src/test/scala/fs2/data/json/jsonpath/JsonPathSpec.scala
@@ -42,7 +42,7 @@ object JsonPathSpec extends SimpleIOSuite {
              }
            }"""
       .lift[IO]
-      .through(filter.raw(path))
+      .through(filter.unsafeRaw(path))
       .parEvalMapUnbounded(_.compile.toList)
       .compile
       .toList
@@ -66,7 +66,7 @@ object JsonPathSpec extends SimpleIOSuite {
     val path = jsonpath"$$.a[3]"
 
     jsonWithArray
-      .through(filter.raw(path))
+      .through(filter.unsafeRaw(path))
       .parEvalMapUnbounded(_.compile.toList)
       .compile
       .toList
@@ -78,7 +78,7 @@ object JsonPathSpec extends SimpleIOSuite {
     val path = jsonpath"$$..a[:2]"
 
     jsonWithArray
-      .through(filter.raw(path))
+      .through(filter.unsafeRaw(path))
       .parEvalMapUnbounded(_.compile.toList)
       .compile
       .toList
@@ -97,7 +97,7 @@ object JsonPathSpec extends SimpleIOSuite {
     val path = jsonpath"$$.a[*]"
 
     jsonWithArray
-      .through(filter.raw(path))
+      .through(filter.unsafeRaw(path))
       .parEvalMapUnbounded(_.compile.toList)
       .compile
       .toList

--- a/xml/src/test/scala/fs2/data/xml/xpath/QueryPipeSpec.scala
+++ b/xml/src/test/scala/fs2/data/xml/xpath/QueryPipeSpec.scala
@@ -42,7 +42,7 @@ object QueryPipeSpec extends SimpleIOSuite {
               |</a>""".stripMargin)
       .covary[IO]
       .through(events())
-      .through(filter.raw(query))
+      .through(filter.unsafeRaw(query))
       .parEvalMapUnbounded(_.compile.toList)
       .compile
       .toList
@@ -73,7 +73,7 @@ object QueryPipeSpec extends SimpleIOSuite {
               |<root><a><c>text</c></a></root>""".stripMargin)
       .covary[IO]
       .through(events())
-      .through(filter.raw(query))
+      .through(filter.unsafeRaw(query))
       .parEvalMapUnbounded(_.compile.toList)
       .compile
       .toList
@@ -140,7 +140,7 @@ object QueryPipeSpec extends SimpleIOSuite {
               |<root><a><c><a>text</a></c></a></root>""".stripMargin)
       .covary[IO]
       .through(events())
-      .through(filter.raw(query))
+      .through(filter.unsafeRaw(query))
       .parEvalMapUnbounded(_.compile.toList)
       .compile
       .toList
@@ -182,7 +182,7 @@ object QueryPipeSpec extends SimpleIOSuite {
               |<root><a><c>text</c></a></root>""".stripMargin)
       .covary[IO]
       .through(events())
-      .through(filter.raw(query))
+      .through(filter.unsafeRaw(query))
       .parEvalMapUnbounded(_.compile.toList)
       .compile
       .toList
@@ -221,7 +221,7 @@ object QueryPipeSpec extends SimpleIOSuite {
               |<a attr="other value">with other value</a>""".stripMargin)
       .covary[IO]
       .through(events())
-      .through(filter.raw(query))
+      .through(filter.unsafeRaw(query))
       .parEvalMapUnbounded(_.compile.toList)
       .compile
       .toList


### PR DESCRIPTION
The documentation now does not bring the unsafe `raw` operators first, and explains better what are the existing operators and what to be careful about.

This also adds a new `through` operator, that allows for streaming handling of path matches.

This PR is a follow-up on the discussion from #666 (cc @mrdziuban)