### PR TITLE
Fix XPath parsing and NFA building with alternatives

### DIFF
--- a/xml/src/main/scala/fs2/data/xml/xpath/XPath.scala
+++ b/xml/src/main/scala/fs2/data/xml/xpath/XPath.scala
@@ -23,10 +23,12 @@ import cats.Eq
 import cats.syntax.all._
 import cats.data.NonEmptyList
 import cats.Show
+import scala.runtime.AbstractFunction1
+import scala.runtime.AbstractFunction3
 
 case class XPath(locations: NonEmptyList[List[Location]])
 
-object XPath {
+object XPath extends AbstractFunction1[NonEmptyList[List[Location]], XPath] {
 
   private implicit val showLocation: Show[List[Location]] =
     _.mkString_("")
@@ -38,7 +40,7 @@ object XPath {
 
 case class Location(axis: Axis, node: Node, predicate: Option[Predicate])
 
-object Location {
+object Location extends AbstractFunction3[Axis, Node, Option[Predicate], Location] {
 
   private implicit val showPredicats: Show[Option[Predicate]] =
     _.fold("")(_.show)
@@ -56,7 +58,7 @@ case class Node(prefix: Option[String], local: Option[String]) {
       case Node(pfx, Some(local))  => name.prefix === pfx && name.local === local
     }
 }
-object Node {
+object Node extends ((Option[String], Option[String]) => Node) {
   implicit val eq: Eq[Node] = Eq.fromUniversalEquals
 
   implicit val show: Show[Node] = _ match {

--- a/xml/src/main/scala/fs2/data/xml/xpath/XPath.scala
+++ b/xml/src/main/scala/fs2/data/xml/xpath/XPath.scala
@@ -22,10 +22,29 @@ package xpath
 import cats.Eq
 import cats.syntax.all._
 import cats.data.NonEmptyList
+import cats.Show
 
 case class XPath(locations: NonEmptyList[List[Location]])
 
+object XPath {
+
+  private implicit val showLocation: Show[List[Location]] =
+    _.mkString_("")
+
+  implicit val show: Show[XPath] =
+    _.locations.mkString_("|")
+
+}
+
 case class Location(axis: Axis, node: Node, predicate: Option[Predicate])
+
+object Location {
+
+  private implicit val showPredicats: Show[Option[Predicate]] =
+    _.fold("")(_.show)
+
+  implicit val show: Show[Location] = loc => show"${loc.axis}${loc.node}${loc.predicate}"
+}
 
 case class Node(prefix: Option[String], local: Option[String]) {
 
@@ -39,12 +58,24 @@ case class Node(prefix: Option[String], local: Option[String]) {
 }
 object Node {
   implicit val eq: Eq[Node] = Eq.fromUniversalEquals
+
+  implicit val show: Show[Node] = _ match {
+    case Node(None, None)                => "*"
+    case Node(None, Some(local))         => local
+    case Node(Some(prefix), None)        => s"$prefix:*"
+    case Node(Some(prefix), Some(local)) => s"$prefix:$local"
+  }
 }
 
 sealed trait Axis
 object Axis {
   case object Child extends Axis
   case object Descendant extends Axis
+
+  implicit val show: Show[Axis] = _ match {
+    case Child      => "/"
+    case Descendant => "//"
+  }
 }
 
 sealed trait Predicate
@@ -59,4 +90,24 @@ object Predicate {
   case class Or(left: Predicate, right: Predicate) extends Predicate
   case class Not(inner: Predicate) extends Predicate
 
+  implicit val show: Show[Predicate] = _ match {
+    case True             => "true"
+    case False            => "false"
+    case Exists(attr)     => show"@$attr"
+    case Eq(attr, value)  => show"""@$attr == "$value""""
+    case Neq(attr, value) => show"""@$attr != "$value""""
+    case And(left, right) => s"${showAnd(left)} && ${showAnd(right)}"
+    case Or(left, right)  => show"$left || $right"
+    case Not(inner)       => s"!${showNot(inner)}"
+  }
+
+  private def showAnd(p: Predicate): String = p match {
+    case Or(_, _) => show"($p)"
+    case _        => p.show
+  }
+
+  private def showNot(p: Predicate): String = p match {
+    case Or(_, _) | And(_, _) => show"($p)"
+    case _                    => p.show
+  }
 }

--- a/xml/src/main/scala/fs2/data/xml/xpath/XPathParser.scala
+++ b/xml/src/main/scala/fs2/data/xml/xpath/XPathParser.scala
@@ -97,8 +97,9 @@ class XPathParser[F[_]](val input: String)(implicit F: MonadError[F, Throwable])
   def parse(): F[XPath] =
     tailRecM((List.empty[Location], List.empty[List[Location]])) { case (current, acc) =>
       peek.flatMap {
-        case None => pure(XPath(NonEmptyList(current.reverse, acc)).asRight[(List[Location], List[List[Location]])])
-        case Some('|') => consume >> location.map(loc => (List(loc), current :: acc).asLeft[XPath])
+        case None =>
+          pure(XPath(NonEmptyList(current.reverse, acc).reverse).asRight[(List[Location], List[List[Location]])])
+        case Some('|') => consume >> location.map(loc => (List(loc), current.reverse :: acc).asLeft[XPath])
         case _         => location.map(loc => (loc :: current, acc).asLeft[XPath])
       }
     }.runA(0)

--- a/xml/src/test/scala/fs2/data/xml/xpath/QueryPipeSpec.scala
+++ b/xml/src/test/scala/fs2/data/xml/xpath/QueryPipeSpec.scala
@@ -19,11 +19,11 @@ package data
 package xml
 package xpath
 
-import literals._
-
-import weaver._
-
+import cats.data.NonEmptyList
 import cats.effect.IO
+import weaver.*
+
+import literals.*
 
 object QueryPipeSpec extends SimpleIOSuite {
 
@@ -56,7 +56,7 @@ object QueryPipeSpec extends SimpleIOSuite {
         ))
   }
 
-  test("simple query") {
+  test("simple query nested") {
 
     val query = xpath"//a/c"
 
@@ -273,6 +273,21 @@ object QueryPipeSpec extends SimpleIOSuite {
           ),
           tokens
         ))
+  }
+
+  pureTest("expression with alternative") {
+    val parsed = xpath"/root/a/b|/root/a/c|//d/e"
+    val expected = XPath(
+      NonEmptyList.of(
+        List(Location(Axis.Child, Node(None, Some("root")), None),
+             Location(Axis.Child, Node(None, Some("a")), None),
+             Location(Axis.Child, Node(None, Some("b")), None)),
+        List(Location(Axis.Child, Node(None, Some("root")), None),
+             Location(Axis.Child, Node(None, Some("a")), None),
+             Location(Axis.Child, Node(None, Some("c")), None)),
+        List(Location(Axis.Descendant, Node(None, Some("d")), None), Location(Axis.Child, Node(None, Some("e")), None))
+      ))
+    expect.same(expected, parsed)
   }
 
 }


### PR DESCRIPTION
Fixes #673 by building alternatives in the right order. While doing so, I discovered that the NFA generation was broken when we had alternatives, and it worked in tests because of a happy case. This PR also fixes the behavior when alternatives are involved.