### PR TITLE
Make path operators more flexible

### DIFF
--- a/json/circe/src/test/scala/fs2/data/json/circe/CirceJsonPathStructuredSpec.scala
+++ b/json/circe/src/test/scala/fs2/data/json/circe/CirceJsonPathStructuredSpec.scala
@@ -1,0 +1,20 @@
+package fs2.data.json.circe
+
+import fs2.data.json.ast.Builder
+import fs2.data.json.codec.Deserializer
+import fs2.data.json.jsonpath.{Data, JsonPathStructuredSpec}
+import io.circe.{Decoder, Json}
+import io.circe.generic.semiauto.deriveDecoder
+
+object CirceJsonPathStructuredSpec extends JsonPathStructuredSpec[Json] {
+
+  override implicit val builder: Builder[Json] = CirceBuilder
+
+  implicit val dataDecoder: Decoder[Data] =
+    deriveDecoder[Data.Number]
+      .either(deriveDecoder[Data.Bool])
+      .map(_.merge)
+
+  override implicit def deserializer: Deserializer[Data] = deserializerForDecoder[Data]
+
+}

--- a/json/circe/src/test/scala/fs2/data/json/circe/CirceJsonPathStructuredSpec.scala
+++ b/json/circe/src/test/scala/fs2/data/json/circe/CirceJsonPathStructuredSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fs2.data.json.circe
 
 import fs2.data.json.ast.Builder

--- a/json/play/src/test/scala/fs2/data/json/playJson/PlayJsonPathStructuredSpec.scala
+++ b/json/play/src/test/scala/fs2/data/json/playJson/PlayJsonPathStructuredSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fs2.data.json.playJson
 
 import fs2.data.json.ast.Builder

--- a/json/play/src/test/scala/fs2/data/json/playJson/PlayJsonPathStructuredSpec.scala
+++ b/json/play/src/test/scala/fs2/data/json/playJson/PlayJsonPathStructuredSpec.scala
@@ -3,10 +3,7 @@ package fs2.data.json.playJson
 import fs2.data.json.ast.Builder
 import fs2.data.json.codec.Deserializer
 import fs2.data.json.jsonpath.{Data, JsonPathStructuredSpec}
-import play.api.libs.json.JsValue
-import play.api.libs.json.Reads
-import play.api.libs.json.JsPath
-import play.api.libs.json.JsResult
+import play.api.libs.json.{JsResult, JsValue, Reads}
 
 object PlayJsonPathStructuredSpec extends JsonPathStructuredSpec[JsValue] {
 

--- a/json/play/src/test/scala/fs2/data/json/playJson/PlayJsonPathStructuredSpec.scala
+++ b/json/play/src/test/scala/fs2/data/json/playJson/PlayJsonPathStructuredSpec.scala
@@ -1,0 +1,27 @@
+package fs2.data.json.playJson
+
+import fs2.data.json.ast.Builder
+import fs2.data.json.codec.Deserializer
+import fs2.data.json.jsonpath.{Data, JsonPathStructuredSpec}
+import play.api.libs.json.JsValue
+import play.api.libs.json.Reads
+import play.api.libs.json.JsPath
+import play.api.libs.json.JsResult
+
+object PlayJsonPathStructuredSpec extends JsonPathStructuredSpec[JsValue] {
+
+  override implicit def builder: Builder[JsValue] = PlayBuilder
+
+  implicit val dataReads: Reads[Data] = new Reads[Data] {
+    override def reads(json: JsValue): JsResult[Data] = {
+      val value = (json \ "value")
+      value
+        .validate[Int]
+        .map(Data.Number(_))
+        .orElse(value.validate[Boolean].map(Data.Bool(_)))
+    }
+  }
+
+  override implicit def deserializer: Deserializer[Data] = deserializerForReads[Data]
+
+}

--- a/json/src/test/scala/fs2/data/json/jsonpath/JsonPathStructuredSpec.scala
+++ b/json/src/test/scala/fs2/data/json/jsonpath/JsonPathStructuredSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fs2.data.json.jsonpath
 
 import fs2.data.json.literals._

--- a/json/src/test/scala/fs2/data/json/jsonpath/JsonPathStructuredSpec.scala
+++ b/json/src/test/scala/fs2/data/json/jsonpath/JsonPathStructuredSpec.scala
@@ -1,0 +1,80 @@
+package fs2.data.json.jsonpath
+
+import fs2.data.json.literals._
+import fs2.data.json.jsonpath.literals._
+import weaver._
+import cats.effect.IO
+import fs2.data.json.ast.Builder
+import fs2.data.json.codec.Deserializer
+
+abstract class JsonPathStructuredSpec[Json] extends SimpleIOSuite {
+
+  implicit def builder: Builder[Json]
+  implicit def deserializer: Deserializer[Data]
+
+  val recursivePath = jsonpath"$$..a"
+
+  val recursiveJson =
+    json"""{
+             "a": {
+               "a": {
+                 "value": true
+               },
+               "value": 2
+             }
+           }"""
+      .lift[IO]
+
+  test("deterministic AST") {
+    recursiveJson
+      .through(filter.values(recursivePath))
+      .compile
+      .toList
+      .map(expect.same(
+        List(
+          builder.makeObject(
+            List("a" -> builder.makeObject(List("value" -> builder.makeTrue)), "value" -> builder.makeNumber("2"))),
+          builder.makeObject(List("value" -> builder.makeTrue))
+        ),
+        _
+      ))
+  }
+
+  test("early AST") {
+    recursiveJson
+      .through(filter.values(recursivePath, deterministic = false))
+      .compile
+      .toList
+      .map(expect.same(
+        List(
+          builder.makeObject(List("value" -> builder.makeTrue)),
+          builder.makeObject(
+            List("a" -> builder.makeObject(List("value" -> builder.makeTrue)), "value" -> builder.makeNumber("2")))
+        ),
+        _
+      ))
+  }
+
+  test("deterministic deserialized") {
+    recursiveJson
+      .through(filter.deserialize(recursivePath))
+      .compile
+      .toList
+      .map(expect.same(List(Data.Number(2), Data.Bool(true)), _))
+  }
+
+  test("early deserialized") {
+    recursiveJson
+      .through(filter.deserialize[Data](recursivePath, deterministic = false))
+      .compile
+      .toList
+      .map(expect.same(List(Data.Bool(true), Data.Number(2)), _))
+  }
+
+}
+
+sealed trait Data
+object Data {
+  final case class Number(value: Int) extends Data
+  final case class Bool(value: Boolean) extends Data
+}

--- a/site/documentation/json/jsonpath.md
+++ b/site/documentation/json/jsonpath.md
@@ -77,6 +77,8 @@ The main operators in the namespace are:
  - `filter.first(path)` which is a `Pipe` returning the tokens of the first match only.
  - `filter.collect(path, collector)` which uses the provided `collector` to aggregate the tokens of each match, and emits all the aggregated results.
  - `filter.values[Json](path)` which builds the AST for each match for any type `Json` with a [`Builder`][json-builder] in scope.
+ - `filter.deserialize[Data](path)` which deserializes matching inputs to `Data` for each match for any type `Data` with a [`Deserializer`][json-deserializer] in scope.
+ - `filter.consume(path, consumer)` which sends all matches as a stream through the provided `consumer`.
  - `filter.through(path, pipe)` which sends all matches as a stream through the provided `pipe`.
 
 @:callout(info)
@@ -126,7 +128,7 @@ json
   .unsafeRunSync()
 ```
 
-The `filter.through` operator allows for handling each match in a streaming fashion.
+The `filter.consume` operator allows for consuming each match in a streaming fashion without emitting any value.
 For instance, let's say you want to save each match in a file, incrementing a counter on each match. You can run the following code.
 
 ```scala mdoc
@@ -144,7 +146,7 @@ val program =
     counter <- Ref[IO].of(0)
     _ <- json
       .lift[IO]
-      .through(filter.through(recursive, saveJson(counter, _)))
+      .through(filter.consume(recursive, saveJson(counter, _)))
       .compile
       .drain
   } yield ()
@@ -181,3 +183,4 @@ json
 [monad-error]: https://typelevel.org/cats/api/cats/MonadError.html
 [jsonpath]: https://goessner.net/articles/JsonPath/index.html
 [json-builder]: index.md#ast-builder-and-tokenizer
+[json-deserializer]: index.md#serializers-and-deserializers

--- a/site/documentation/xml/xpath.md
+++ b/site/documentation/xml/xpath.md
@@ -84,6 +84,7 @@ The main operators in the namespace are:
  - `filter.first(xpath)` which is a `Pipe` returning the events of the first match only.
  - `filter.collect(xpath, collector)` which uses the provided `collector` to aggregate the events of each match, and emits all the aggregated results.
  - `filter.dom[Node](xpath)` which builds the DOM for each match for any DOM type `Node` with a [`DocumentBuilder`][dom-builder] in scope.
+ - `filter.consumer(xpath, consumer)` which sends all matches as a stream through the provided `consumer`.
  - `filter.through(xpath, pipe)` which sends all matches as a stream through the provided `pipe`.
 
 @:callout(info)
@@ -117,7 +118,7 @@ stream
   .unsafeRunSync()
 ```
 
-The `filter.through` operator allows for handling each match in a streaming fashion.
+The `filter.consumer` operator allows for handling each match in a streaming fashion without emitting any value.
 For instance, let's say you want to save each match in a file, incrementing a counter on each match. You can run the following code.
 
 ```scala mdoc
@@ -135,7 +136,7 @@ val program =
     counter <- Ref[IO].of(0)
     _ <- stream
       .lift[IO]
-      .through(filter.through(path, saveXml(counter, _)))
+      .through(filter.consume(path, saveXml(counter, _)))
       .compile
       .drain
   } yield ()


### PR DESCRIPTION
This reworks the new XPath and JSONPath operators to make them more flexible:
 - the operator taking a `Pipe` that emits nothing is now called `consume` to reflect its purpose more closely
 - the `through` operator now takes any pipe, and will emit the output either deterministically or not depending on the `deterministic` parameter
 - JSONPath now also has a `filter.deserialize[Data](jsonpath)` pipe, that allows to deserialize selected data directly.