### PR TITLE
Publish to Central Portal instead of legacy OSSRH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,15 +82,15 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         run: mkdir -p json/.native/target json/play/.jvm/target text/native/target cbor-json/native/target finite-state/native/target unidocs/target msgpack/.jvm/target cbor/js/target finite-state/js/target text/js/target json/play/.js/target json/.jvm/target xml/scala-xml/.native/target csv/jvm/target msgpack/.native/target xml/.jvm/target xml/.js/target cbor/native/target json/circe/.native/target finite-state/jvm/target cbor-json/js/target cbor/jvm/target csv/native/target json/circe/.jvm/target csv/js/target csv/generic/jvm/target text/jvm/target xml/.native/target json/diffson/.native/target msgpack/.js/target json/diffson/.js/target cbor-json/jvm/target json/interpolators/.jvm/target json/.js/target json/interpolators/.js/target csv/generic/js/target json/circe/.js/target json/diffson/.jvm/target xml/scala-xml/.js/target csv/generic/native/target xml/scala-xml/.jvm/target json/interpolators/.native/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         run: tar cf targets.tar json/.native/target json/play/.jvm/target text/native/target cbor-json/native/target finite-state/native/target unidocs/target msgpack/.jvm/target cbor/js/target finite-state/js/target text/js/target json/play/.js/target json/.jvm/target xml/scala-xml/.native/target csv/jvm/target msgpack/.native/target xml/.jvm/target xml/.js/target cbor/native/target json/circe/.native/target finite-state/jvm/target cbor-json/js/target cbor/jvm/target csv/native/target json/circe/.jvm/target csv/js/target csv/generic/jvm/target text/jvm/target xml/.native/target json/diffson/.native/target msgpack/.js/target json/diffson/.js/target cbor-json/jvm/target json/interpolators/.jvm/target json/.js/target json/interpolators/.js/target csv/generic/js/target json/circe/.js/target json/diffson/.jvm/target xml/scala-xml/.js/target csv/generic/native/target xml/scala-xml/.jvm/target json/interpolators/.native/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         uses: actions/upload-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
@@ -99,7 +99,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         os: [ubuntu-22.04]

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,3 @@
 -J-Xms2g
 -J-Xmx4g
+-Dsun.net.client.defaultReadTimeout=60000

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ import com.typesafe.tools.mima.core._
 import laika.config._
 import sbt.Def._
 import scala.scalanative.build._
+import xerial.sbt.Sonatype.sonatypeCentralHost
 
 val scala212 = "2.12.20"
 val scala213 = "2.13.16"
@@ -45,6 +46,8 @@ ThisBuild / developers := List(
 ThisBuild / crossScalaVersions := Seq(scala212, scala213, scala3)
 ThisBuild / scalaVersion := scala213
 ThisBuild / tlJdkRelease := Some(11)
+
+ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 
 val commonSettings = List(
   versionScheme := Some("early-semver"),

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,7 @@ ThisBuild / scalaVersion := scala213
 ThisBuild / tlJdkRelease := Some(11)
 
 ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
 
 val commonSettings = List(
   versionScheme := Some("early-semver"),


### PR DESCRIPTION
Since OSSRH will be [sunset end of June](https://central.sonatype.org/news/20250326_ossrh_sunset/), let's anticipate and migrate `org.gnieh` namespace to the new central portal already.

The namespace has been migrated and the new secrets have been generated and configured at github organization level.