### PR TITLE
Add ++ to concatenate CSV rows

### DIFF
--- a/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
@@ -219,6 +219,15 @@ case class RowF[H[+a] <: Option[a], Header](values: NonEmptyList[String],
     */
   def dropHeaders: Row = Row(values, line)
 
+  /**
+   * Combine two rows by concatenating their values and headers (if present). The resulting row will have no line number.
+   * Note that if the rows have headers, these should be disjoint to avoid duplicates causing trouble downstream.
+   */
+  def ++(other: RowF[H, Header]): RowF[H, Header] =
+    new RowF(values ::: other.values,
+             headers.flatMap(h1 => other.headers.map(h2 => h1 ::: h2)).asInstanceOf[H[NonEmptyList[Header]]],
+             None)
+
   // let's cache this to avoid recomputing it for every call to `as` or similar method
   // the `Option.get` call is safe since this field is only called in a context where a `HasHeaders`
   // instance is provided, meaning that the `Option` is `Some`
@@ -239,4 +248,8 @@ object RowF {
   implicit object functor extends Functor[CsvRow[*]] {
     override def map[A, B](fa: CsvRow[A])(f: A => B): CsvRow[B] = fa.copy(headers = Some(fa.headers.get.map(f)))
   }
+
+  implicit val orderRow: Order[Row] = Order.by(r => (r.values, r.line))
+  implicit def orderCsvRow[Header: Order]: Order[CsvRow[Header]] =
+    Order.by(r => (r.values, r.headers: Option[NonEmptyList[Header]], r.line))
 }

--- a/csv/shared/src/test/scala/fs2/data/csv/RowFTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/RowFTest.scala
@@ -16,8 +16,9 @@
 
 package fs2.data.csv
 
-import weaver._
 import cats.data.NonEmptyList
+import cats.syntax.all._
+import weaver._
 
 object RowFTest extends SimpleIOSuite {
 
@@ -71,5 +72,11 @@ object RowFTest extends SimpleIOSuite {
   pureTest("Row.asOptionalAt should return decoded value for non-empty cells") {
     val row = Row(NonEmptyList.of("", "2", "3"))
     expect(row.asOptionalAt[Int](1).contains(Some(2)))
+  }
+
+  pureTest("RowF.++ should return properly concatenated row") {
+    val rowA = Row(NonEmptyList.of("A1", "A2"), None)
+    val rowB = Row(NonEmptyList.of("A3", "A4"), None)
+    expect((rowA ++ rowB) === Row(NonEmptyList.of("A1", "A2", "A3", "A4"), None))
   }
 }


### PR DESCRIPTION
When serializing nested case classes, it comes in handy to be able to concatenate CSV rows (with or without headers), hence this adds a `++` (feel free to bikeshed the name). Also adds `Order` instances for (CSV)Row as they're useful as well.